### PR TITLE
fix: use movetoworkspacesilent for focused client only

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -148,12 +148,13 @@ hl.bind("SUPER + P", hl.dsp.window.pin(), { description = "Window: Pin" })
 
 --#/# bind = SUPER+ALT, Hash,, -- Send to workspace -- (1, 2, 3,...)
 --# We use raw keycodes because some keyboard layouts register number keys as different chars. The codes can be verified with `wev`
+
 for i = 1, 10 do
-    local numberkey = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 }
-    hl.bind("SUPER + ALT + code:" .. numberkey[i], function()
-        hl.dispatch(hl.dsp.window.move({ workspace = workspace_in_group(i), follow = false }))
+    hl.bind("SUPER + ALT + " .. (i % 10), function()
+        hl.exec_cmd("hyprctl dispatch movetoworkspacesilent " .. workspace_in_group(i))
     end)
 end
+
 --# keypad numbers
 for i = 1, 10 do
     local numpadkey = { 87, 88, 89, 83, 84, 85, 79, 80, 81, 90 }

--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -148,18 +148,31 @@ hl.bind("SUPER + P", hl.dsp.window.pin(), { description = "Window: Pin" })
 
 --#/# bind = SUPER+ALT, Hash,, -- Send to workspace -- (1, 2, 3,...)
 --# We use raw keycodes because some keyboard layouts register number keys as different chars. The codes can be verified with `wev`
-
 for i = 1, 10 do
-    hl.bind("SUPER + ALT + " .. (i % 10), function()
-        hl.exec_cmd("hyprctl dispatch movetoworkspacesilent " .. workspace_in_group(i))
+    local numberkey = {10,11,12,13,14,15,16,17,18,19}
+
+    hl.bind("SUPER + ALT + code:" .. numberkey[i], function()
+        hl.dispatch(
+            hl.dsp.window.move({
+                workspace = workspace_in_group(i),
+                follow = false,
+                silent = true
+            })
+        )
     end)
 end
-
 --# keypad numbers
 for i = 1, 10 do
     local numpadkey = { 87, 88, 89, 83, 84, 85, 79, 80, 81, 90 }
+
     hl.bind("SUPER + ALT + code:" .. numpadkey[i], function()
-        hl.dispatch(hl.dsp.window.move({ workspace = workspace_in_group(i), follow = false }))
+        hl.dispatch(
+            hl.dsp.window.move({
+                workspace = workspace_in_group(i),
+                follow = false,
+                silent = true
+            })
+        )
     end)
 end
 


### PR DESCRIPTION
### Description

Fix grouped window movement behavior when using `SUPER + ALT + number`.

Previously, moving a focused window inside a grouped/tabbed container moved the entire group. Replaced `window.move()` with `movetoworkspacesilent` so only the active focused client is sent to the target workspace.
