### PR TITLE
fix(colors): write material_colors.scss atomically and validate theme replacements

### DIFF
--- a/dots/.config/quickshell/ii/scripts/colors/applycolor.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/applycolor.sh
@@ -64,6 +64,11 @@ with open(template_path, "r") as f:
 for name, val in vars_dict.items():
     content = content.replace(name, val)
 
+import re
+if re.search(r"#\$[a-zA-Z0-9_]+", content):
+    print("Error: Unreplaced placeholders found in Kitty theme. Aborting update.", file=sys.stderr)
+    sys.exit(1)
+
 tmp_path = output_path + ".tmp"
 with open(tmp_path, "w") as f:
     f.write(content)
@@ -127,6 +132,11 @@ for name, val in vars_dict.items():
     content = content.replace(name, val)
 
 content = content.replace("$alpha", alpha)
+
+import re
+if re.search(r"#\$[a-zA-Z0-9_]+", content):
+    print("Error: Unreplaced placeholders found in Terminal sequences. Aborting update.", file=sys.stderr)
+    sys.exit(1)
 
 tmp_path = output_path + ".tmp"
 with open(tmp_path, "w") as f:

--- a/dots/.config/quickshell/ii/scripts/colors/applycolor_vynx.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/applycolor_vynx.sh
@@ -53,6 +53,11 @@ with open(template_path, "r") as f:
 for name, val in vars_dict.items():
     content = content.replace(name, val)
 
+import re
+if re.search(r"#\$[a-zA-Z0-9_]+", content):
+    print("Error: Unreplaced placeholders found in Kitty theme. Aborting update.", file=sys.stderr)
+    sys.exit(1)
+
 tmp_path = output_path + ".tmp"
 with open(tmp_path, "w") as f:
     f.write(content)
@@ -116,6 +121,11 @@ for name, val in vars_dict.items():
     content = content.replace(name, val)
 
 content = content.replace("$alpha", alpha)
+
+import re
+if re.search(r"#\$[a-zA-Z0-9_]+", content):
+    print("Error: Unreplaced placeholders found in Terminal sequences. Aborting update.", file=sys.stderr)
+    sys.exit(1)
 
 tmp_path = output_path + ".tmp"
 with open(tmp_path, "w") as f:

--- a/dots/.config/quickshell/ii/scripts/colors/generate_colors_material_vynx.py
+++ b/dots/.config/quickshell/ii/scripts/colors/generate_colors_material_vynx.py
@@ -164,6 +164,22 @@ for color, val in term_source_colors.items():
             harmonized = boost_chroma_tone(harmonized, 1, 1 + (args.term_fg_boost * (1 if darkmode else -1)))
         term_colors[color] = argb_to_hex(harmonized)
 
+# Define high-contrast semantic mappings to prevent invisible text in light mode
+if darkmode:
+    term_colors['term_bg'] = term_colors['term0']
+    term_colors['term_fg'] = term_colors['term7']
+    term_colors['ansi0'] = term_colors['term0']
+    term_colors['ansi7'] = term_colors['term7']
+    term_colors['ansi8'] = term_colors['term8']
+    term_colors['ansi15'] = term_colors['term15']
+else:
+    term_colors['term_bg'] = term_colors['term0']      # light background
+    term_colors['term_fg'] = term_colors['term7']      # dark foreground
+    term_colors['ansi0'] = term_colors['term7']        # dark black
+    term_colors['ansi7'] = term_colors['term0']        # light white
+    term_colors['ansi8'] = term_colors['term8']        # dark grey
+    term_colors['ansi15'] = term_colors['term0']       # light white
+
 if args.debug == False:
     print(f"$darkmode: {darkmode};")
     print(f"$transparent: {transparent};")

--- a/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
@@ -322,7 +322,8 @@ switch() {
         python3 "$HOME/.config/quickshell/ii/scripts/colors/recolor_icons.py"
         source "$(eval echo $ILLOGICAL_IMPULSE_VIRTUAL_ENV)/bin/activate"
         python3 "$SCRIPT_DIR/generate_colors_material.py" "${generate_colors_material_args[@]}" \
-            > "$STATE_DIR"/user/generated/material_colors.scss
+            > "$STATE_DIR"/user/generated/material_colors.scss.tmp && \
+        mv "$STATE_DIR"/user/generated/material_colors.scss.tmp "$STATE_DIR"/user/generated/material_colors.scss
         deactivate
         "$SCRIPT_DIR"/applycolor.sh
     fi

--- a/dots/.config/quickshell/ii/scripts/colors/switchwall_vynx.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/switchwall_vynx.sh
@@ -316,7 +316,8 @@ switch() {
     python3 "$HOME/.config/quickshell/ii/scripts/colors/recolor_icons.py"
     source "$(eval echo $ILLOGICAL_IMPULSE_VIRTUAL_ENV)/bin/activate"
     python3 "$SCRIPT_DIR/generate_colors_material_vynx.py" "${generate_colors_material_args[@]}" \
-        > "$STATE_DIR"/user/generated/material_colors.scss
+        > "$STATE_DIR"/user/generated/material_colors.scss.tmp && \
+    mv "$STATE_DIR"/user/generated/material_colors.scss.tmp "$STATE_DIR"/user/generated/material_colors.scss
     deactivate
     "$SCRIPT_DIR"/applycolor_vynx.sh
 


### PR DESCRIPTION
## Describe your changes

This PR addresses theme configuration errors in Kitty and resolves an issue with unreplaced placeholders leaking into terminal sequences.

1. **Atomic SCSS Writes**: Updated `switchwall.sh` and `switchwall_vynx.sh` to write generated colors to a temporary file (`material_colors.scss.tmp`) before moving it atomically via `mv` (replacing the direct `>` redirection). This ensures `applycolor` scripts never read a partially written SCSS file mid-generation.
2. **Restored Vynx Mappings**: Re-introduced the missing high-contrast semantic mapping block in `generate_colors_material_vynx.py`. This ensures core terminal variables like `ansi0`, `term_fg`, and `$term_bg` are properly defined and generated.
3. **Placeholder Safeguard**: Added a regex verification step to the Python blocks in both `applycolor.sh` and `applycolor_vynx.sh`. If any unreplaced `#$variable` placeholders are detected in the final template, the update will safely abort to prevent pushing a broken configuration.

## Is it ready? Questions/feedback needed?

Yes, it should be ready as it's good on my end but I'm not opposed to feedback on this 