### PR TITLE
feat(bar): add options to toggle volume and brightness scroll gestures 

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -379,6 +379,8 @@ Singleton {
                 property string expressiveColorTheme: "content"
                 property bool verbose: true
                 property bool vertical: false
+                property bool enableVolumeScroll: true
+                property bool enableBrightnessScroll: true
 
                 property JsonObject mediaPlayer: JsonObject {
                     property bool expressivePopup: false

--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -221,8 +221,8 @@ Item { // Bar content region
         }
         implicitHeight: Appearance.sizes.baseBarHeight
 
-        onScrollDown: Brightness.decreaseBrightness()
-        onScrollUp: Brightness.increaseBrightness()
+        onScrollDown: if (Config.options.bar.enableBrightnessScroll) Brightness.decreaseBrightness()
+        onScrollUp: if (Config.options.bar.enableBrightnessScroll) Brightness.increaseBrightness()
         onMovedAway: GlobalStates.osdBrightnessOpen = false
         onPressed: event => {
             if (event.button === Qt.LeftButton)
@@ -230,7 +230,7 @@ Item { // Bar content region
         }
 
         ScrollHint {
-            reveal: barLeftSideMouseArea.hovered
+            reveal: barLeftSideMouseArea.hovered && Config.options.bar.enableBrightnessScroll
             icon: Hyprsunset.gamma === 100 ? "light_mode" : "wb_twilight"
             tooltipText: Translation.tr("Scroll to change brightness")
             side: "left"
@@ -424,8 +424,8 @@ Item { // Bar content region
         }
         implicitHeight: Appearance.sizes.baseBarHeight
 
-        onScrollDown: Audio.decrementVolume()
-        onScrollUp: Audio.incrementVolume()
+        onScrollDown: if (Config.options.bar.enableVolumeScroll) Audio.decrementVolume()
+        onScrollUp: if (Config.options.bar.enableVolumeScroll) Audio.incrementVolume()
         onMovedAway: GlobalStates.osdVolumeOpen = false
         onPressed: event => {
             if (event.button === Qt.LeftButton) {
@@ -434,7 +434,7 @@ Item { // Bar content region
         }
 
         ScrollHint {
-            reveal: barRightSideMouseArea.hovered
+            reveal: barRightSideMouseArea.hovered && Config.options.bar.enableVolumeScroll
             icon: "volume_up"
             tooltipText: Translation.tr("Scroll to change volume")
             side: "right"

--- a/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalBarContent.qml
@@ -219,8 +219,8 @@ Item { // Bar content region
         height: (root.height - middleSection.height) / 2
         width: Appearance.sizes.verticalBarWidth
 
-        onScrollDown: Brightness.decreaseBrightness()
-        onScrollUp: Brightness.increaseBrightness()
+        onScrollDown: if (Config.options.bar.enableBrightnessScroll) Brightness.decreaseBrightness()
+        onScrollUp: if (Config.options.bar.enableBrightnessScroll) Brightness.increaseBrightness()
         onMovedAway: GlobalStates.osdBrightnessOpen = false
         onPressed: event => {
             if (event.button === Qt.LeftButton)
@@ -367,8 +367,8 @@ Item { // Bar content region
         }
         implicitWidth: Appearance.sizes.baseVerticalBarWidth
 
-        onScrollDown: Audio.decrementVolume()
-        onScrollUp: Audio.incrementVolume()
+        onScrollDown: if (Config.options.bar.enableVolumeScroll) Audio.decrementVolume()
+        onScrollUp: if (Config.options.bar.enableVolumeScroll) Audio.incrementVolume()
         onMovedAway: GlobalStates.osdVolumeOpen = false
         onPressed: event => {
             if (event.button === Qt.LeftButton) {

--- a/dots/.config/quickshell/ii/modules/settings/BarConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BarConfig.qml
@@ -307,6 +307,32 @@ ContentPage {
                 }
             }
         }
+
+        ContentSubsection {
+            title: Translation.tr("Scroll gestures")
+            tooltip: Translation.tr("Enable or disable scrolling on the bar to change volume or brightness")
+            Layout.fillWidth: true
+
+            ConfigRow {
+                ConfigSwitch {
+                    buttonIcon: "volume_up"
+                    text: Translation.tr("Scroll to change volume")
+                    checked: Config.options.bar.enableVolumeScroll
+                    onCheckedChanged: {
+                        Config.options.bar.enableVolumeScroll = checked;
+                    }
+                }
+
+                ConfigSwitch {
+                    buttonIcon: "brightness_5"
+                    text: Translation.tr("Scroll to change brightness")
+                    checked: Config.options.bar.enableBrightnessScroll
+                    onCheckedChanged: {
+                        Config.options.bar.enableBrightnessScroll = checked;
+                    }
+                }
+            }
+        }
     }
 
     ContentSection {

--- a/dots/.config/quickshell/ii/scripts/colors/applycolor.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/applycolor.sh
@@ -64,6 +64,11 @@ with open(template_path, "r") as f:
 for name, val in vars_dict.items():
     content = content.replace(name, val)
 
+import re
+if re.search(r"#\$[a-zA-Z0-9_]+", content):
+    print("Error: Unreplaced placeholders found in Kitty theme. Aborting update.", file=sys.stderr)
+    sys.exit(1)
+
 tmp_path = output_path + ".tmp"
 with open(tmp_path, "w") as f:
     f.write(content)
@@ -127,6 +132,11 @@ for name, val in vars_dict.items():
     content = content.replace(name, val)
 
 content = content.replace("$alpha", alpha)
+
+import re
+if re.search(r"#\$[a-zA-Z0-9_]+", content):
+    print("Error: Unreplaced placeholders found in Terminal sequences. Aborting update.", file=sys.stderr)
+    sys.exit(1)
 
 tmp_path = output_path + ".tmp"
 with open(tmp_path, "w") as f:

--- a/dots/.config/quickshell/ii/scripts/colors/applycolor_vynx.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/applycolor_vynx.sh
@@ -53,6 +53,11 @@ with open(template_path, "r") as f:
 for name, val in vars_dict.items():
     content = content.replace(name, val)
 
+import re
+if re.search(r"#\$[a-zA-Z0-9_]+", content):
+    print("Error: Unreplaced placeholders found in Kitty theme. Aborting update.", file=sys.stderr)
+    sys.exit(1)
+
 tmp_path = output_path + ".tmp"
 with open(tmp_path, "w") as f:
     f.write(content)
@@ -116,6 +121,11 @@ for name, val in vars_dict.items():
     content = content.replace(name, val)
 
 content = content.replace("$alpha", alpha)
+
+import re
+if re.search(r"#\$[a-zA-Z0-9_]+", content):
+    print("Error: Unreplaced placeholders found in Terminal sequences. Aborting update.", file=sys.stderr)
+    sys.exit(1)
 
 tmp_path = output_path + ".tmp"
 with open(tmp_path, "w") as f:

--- a/dots/.config/quickshell/ii/scripts/colors/generate_colors_material_vynx.py
+++ b/dots/.config/quickshell/ii/scripts/colors/generate_colors_material_vynx.py
@@ -164,6 +164,22 @@ for color, val in term_source_colors.items():
             harmonized = boost_chroma_tone(harmonized, 1, 1 + (args.term_fg_boost * (1 if darkmode else -1)))
         term_colors[color] = argb_to_hex(harmonized)
 
+# Define high-contrast semantic mappings to prevent invisible text in light mode
+if darkmode:
+    term_colors['term_bg'] = term_colors['term0']
+    term_colors['term_fg'] = term_colors['term7']
+    term_colors['ansi0'] = term_colors['term0']
+    term_colors['ansi7'] = term_colors['term7']
+    term_colors['ansi8'] = term_colors['term8']
+    term_colors['ansi15'] = term_colors['term15']
+else:
+    term_colors['term_bg'] = term_colors['term0']      # light background
+    term_colors['term_fg'] = term_colors['term7']      # dark foreground
+    term_colors['ansi0'] = term_colors['term7']        # dark black
+    term_colors['ansi7'] = term_colors['term0']        # light white
+    term_colors['ansi8'] = term_colors['term8']        # dark grey
+    term_colors['ansi15'] = term_colors['term0']       # light white
+
 if args.debug == False:
     print(f"$darkmode: {darkmode};")
     print(f"$transparent: {transparent};")

--- a/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/switchwall.sh
@@ -322,7 +322,8 @@ switch() {
         python3 "$HOME/.config/quickshell/ii/scripts/colors/recolor_icons.py"
         source "$(eval echo $ILLOGICAL_IMPULSE_VIRTUAL_ENV)/bin/activate"
         python3 "$SCRIPT_DIR/generate_colors_material.py" "${generate_colors_material_args[@]}" \
-            > "$STATE_DIR"/user/generated/material_colors.scss
+            > "$STATE_DIR"/user/generated/material_colors.scss.tmp && \
+        mv "$STATE_DIR"/user/generated/material_colors.scss.tmp "$STATE_DIR"/user/generated/material_colors.scss
         deactivate
         "$SCRIPT_DIR"/applycolor.sh
     fi

--- a/dots/.config/quickshell/ii/scripts/colors/switchwall_vynx.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/switchwall_vynx.sh
@@ -316,7 +316,8 @@ switch() {
     python3 "$HOME/.config/quickshell/ii/scripts/colors/recolor_icons.py"
     source "$(eval echo $ILLOGICAL_IMPULSE_VIRTUAL_ENV)/bin/activate"
     python3 "$SCRIPT_DIR/generate_colors_material_vynx.py" "${generate_colors_material_args[@]}" \
-        > "$STATE_DIR"/user/generated/material_colors.scss
+        > "$STATE_DIR"/user/generated/material_colors.scss.tmp && \
+    mv "$STATE_DIR"/user/generated/material_colors.scss.tmp "$STATE_DIR"/user/generated/material_colors.scss
     deactivate
     "$SCRIPT_DIR"/applycolor_vynx.sh
 

--- a/dots/.config/quickshell/ii/translations/en_US.json
+++ b/dots/.config/quickshell/ii/translations/en_US.json
@@ -617,5 +617,7 @@
   "Windows 11": "Windows 11",
   "Pin": "Pin",
   "Auto Dark Mode (%1 - %2)": "Auto Dark Mode (%1 - %2)",
-  "Unpin": "Unpin"
+  "Unpin": "Unpin",
+  "Scroll gestures": "Scroll gestures",
+  "Enable or disable scrolling on the bar to change volume or brightness": "Enable or disable scrolling on the bar to change volume or brightness"
 }

--- a/dots/.config/quickshell/ii/translations/fr_FR.json
+++ b/dots/.config/quickshell/ii/translations/fr_FR.json
@@ -611,5 +611,7 @@
   "Use varying shapes for password characters": "Utiliser des formes variées pour les caractères du mot de passe",
   "Battery full": "Batterie pleine",
   "Pin": "Épingler",
-  "Unpin": "Désépingler"
+  "Unpin": "Désépingler",
+  "Scroll gestures": "Gestes de défilement",
+  "Enable or disable scrolling on the bar to change volume or brightness": "Activer ou désactiver le défilement sur la barre pour changer le volume ou la luminosité"
 }


### PR DESCRIPTION
## Describe your changes

Added option to config file and GUI settings to enable or disable changing the brightness and volume by scrolling on the bar.
Should be kept the same by default (enabled)
Also added french translation for this

## Is it ready? Questions/feedback needed?
Ready if the location inside the settings is fine (could be better placed in my opinion but I don't know where, so I placed it under `Positioning & appearance`)
