### PR TITLE
feat(bar): add option to change keyboard layout abbrev to lowercase/u…

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -612,6 +612,9 @@ Singleton {
                     property bool enableBluetoothConnectionPopup: true
                     property bool enableKeyboardLayoutTransitionPopup: true
                 }
+                property JsonObject keyboardLayout: JsonObject {
+                    property bool uppercaseLayout: false
+                }
                 property string bluetoothDevicesLayout: "expressive" // Options: classic, expressive
                 property JsonObject sizes: JsonObject {
                     property int height: 40 // horizontal mode

--- a/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveKeyboardLayout.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveKeyboardLayout.qml
@@ -10,6 +10,7 @@ import Quickshell.Io
 MouseArea {
     id: root
     property bool vertical: false
+    property bool uppercaseLayout: Config.options.bar.keyboardLayout.uppercaseLayout
     
     readonly property bool hasMultipleLayouts: HyprlandXkb.layoutCodes.length > 1
     visible: HyprlandXkb.layoutCodes.length >= 1
@@ -22,7 +23,8 @@ MouseArea {
     function abbreviateLayoutCode(fullCode) {
         if (!fullCode) return "";
         const firstLayout = fullCode.split(':')[0].split('-')[0];
-        return firstLayout.slice(0, 2).toUpperCase();
+        let abbr = firstLayout.slice(0, 2);
+        return root.uppercaseLayout ? abbr.toUpperCase() : abbr.toLowerCase();
     }
 
     Process {

--- a/dots/.config/quickshell/ii/modules/ii/bar/KeyboardLayoutWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/KeyboardLayoutWidget.qml
@@ -10,6 +10,7 @@ import Quickshell.Io
 MouseArea {
     id: root
     property bool vertical: false
+    property bool uppercaseLayout: Config.options.bar.keyboardLayout.uppercaseLayout
 
     readonly property bool hasMultipleLayouts: HyprlandXkb.layoutCodes.length > 1
 
@@ -24,10 +25,11 @@ MouseArea {
     function abbreviateLayoutCode(fullCode) {
         if (!fullCode)
             return "";
-        return fullCode.split(':').map(layout => {
+        let abbr = fullCode.split(':').map(layout => {
             const baseLayout = layout.split('-')[0];
             return baseLayout.slice(0, 2);
-        }).join('\n').toUpperCase();
+        }).join('\n')
+        return root.uppercaseLayout ? abbr.toUpperCase() : abbr.toLowerCase();
     }
 
     Process {

--- a/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalKeyboardLayoutWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalKeyboardLayoutWidget.qml
@@ -10,6 +10,7 @@ import qs.modules.ii.bar as Bar
 
 MouseArea {
     id: root
+    property bool uppercaseLayout: Config.options.bar.keyboardLayout.uppercaseLayout
 
     readonly property bool hasMultipleLayouts: HyprlandXkb.layoutCodes.length > 1
 
@@ -25,7 +26,8 @@ MouseArea {
             return "";
         // Only take the first layout if multiple exist, or just take the first 2 letters of the primary one
         const firstLayout = fullCode.split(':')[0].split('-')[0];
-        return firstLayout.slice(0, 2).toUpperCase();
+        let abbr = firstLayout.slice(0, 2);
+        return root.uppercaseLayout ? abbr.toUpperCase() : abbr.toLowerCase();
     }
 
     Process {

--- a/dots/.config/quickshell/ii/modules/settings/BarConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BarConfig.qml
@@ -1160,6 +1160,20 @@ ContentPage {
     }
 
     ContentSection {
+        icon: "keyboard"
+        title: Translation.tr("Keyboard layout")
+
+        ConfigSwitch {
+            buttonIcon: "uppercase"
+            text: Translation.tr("Uppercase layout abbreviation")
+            checked: Config.options.bar.keyboardLayout.uppercaseLayout
+            onCheckedChanged: {
+                Config.options.bar.keyboardLayout.uppercaseLayout = checked;
+            }
+        }
+    }
+
+    ContentSection {
         icon: "tooltip"
         title: Translation.tr("Tooltips")
 


### PR DESCRIPTION
## Describe your changes

Just a little enhancement to be able to change keyboard layout abbrev to upper or lower case. 
Also placed this config above the `Tooltips` config in the `Bar` settings.

## Is it ready? Questions/feedback needed?
Ready, but not sure about the config positioning in the settings 