### PR TITLE
feat(bar): add swap pill to system monitor popup

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveResourcesPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveResourcesPopup.qml
@@ -394,6 +394,62 @@ StyledPopup {
             }
         }
 
+        // SWAP Pill
+        Rectangle {
+            visible: Config.options.bar.resources.alwaysShowSwap
+            implicitWidth: 380
+            implicitHeight: 64
+            radius: Appearance.rounding.full
+            color: Appearance.colors.colSecondaryContainer
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.margins: 12
+                spacing: 12
+
+                MaterialShape {
+                    shapeString: "Circle"
+                    implicitSize: 40
+                    color: Appearance.colors.colLayer4
+
+                    MaterialSymbol {
+                        anchors.centerIn: parent
+                        text: "swap_horiz"
+                        iconSize: 22
+                        color: Appearance.colors.colOnLayer4
+                    }
+                }
+
+                ColumnLayout {
+                    spacing: -2
+                    StyledText {
+                        text: "SWAP"
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        font.weight: Font.Bold
+                        color: Appearance.colors.colOnSecondaryContainer
+                    }
+                    StyledText {
+                        text: (ResourceUsage.swapUsed / (1024 * 1024)).toFixed(1) + " GB / " + (ResourceUsage.swapTotal / (1024 * 1024)).toFixed(0) + " GB"
+                        font.pixelSize: Appearance.font.pixelSize.normal
+                        font.weight: Font.DemiBold
+                        color: Appearance.colors.colOnSecondaryContainer
+                    }
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                StyledText {
+                    text: Math.round(ResourceUsage.swapUsedPercentage * 100) + "%"
+                    font.pixelSize: 24
+                    font.weight: Font.Black
+                    color: Appearance.colors.colOnSecondaryContainer
+                    Layout.rightMargin: 12
+                }
+            }
+        }
+
         // Disk Pill
         Rectangle {
             implicitWidth: 380


### PR DESCRIPTION
## Describe your changes

Added a swap pill in between the RAM and Disk one inside the system monitor popup. I followed the same style as the existing two.

## Is it ready? Questions/feedback needed?

Considering that some systems doesn't have swap, I made it show only if "alwaysShowSwap" is true on the `~/.config/illogical-impulse/config.json`
It's maybe not perfect but it's the best solution I've found to handle this. And I kinda want feedback on that part.

Other than this it should be ready