### PR TITLE
Add transliteration support to sidebar and overview translators

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
@@ -571,12 +571,13 @@ Item {
 
                         // Main translated output
                         StyledText {
-                            text: root.translatedText
-                            visible: text.length > 0
+                            text: root.translatedText !== "" ? root.translatedText : Translation.tr("Translation will appear here...")
+                            visible: true
 
                             wrapMode: Text.Wrap
                             font.pixelSize: Appearance.font.pixelSize.huge
-                            color: colResultText
+                            color: root.translatedText !== "" ? colResultText : Appearance.colors.colSubtext
+                            opacity: root.translatedText !== "" ? 1.0 : 0.6
 
                             Layout.fillWidth: true
                         }

--- a/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
@@ -224,45 +224,42 @@ Item {
 
     Process {
         id: translateProc
-        property bool canTransliterate: ([
-            "العربية","বাংলা","भोजपुरी","简体中文","繁體中文","粵語","文言","ગુજરાતી","हिन्दी",
-            "日本語","ಕನ್ನಡ","한국어","मराठी","پښتو","فارسی","ਪੰਜਾਬੀ","русский","தமிழ்",
-            "తెలుగు","ไทย","اردو"
-        ].includes(root.targetLanguage))
+        property bool probeDone: false
+        property bool canTransliterate: true
         property string buffer: ""
-        command: [
-            "bash", "-c",
-            `trans -brief -no-bidi` +
-            ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'` +
-            (
-                canTransliterate
-                ? ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}+@${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
-                : ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
-            ) +
-            ` '${StringUtils.shellSingleQuoteEscape(root.searchQuery.trim())}'`
-        ]
+        command: {
+            const s = StringUtils.shellSingleQuoteEscape
+            const src = s(root.sourceLanguage)
+            const tgt = s(root.targetLanguage)
+            const inp = s(root.searchQuery.trim())
+            const t = canTransliterate ? `${tgt}+@${tgt}` : tgt
+
+            return ["bash", "-c",
+                `trans -brief -no-bidi -source '${src}' -target '${t}' '${inp}'`
+            ]
+        }
         stdout: SplitParser {
-            onRead: data => {
-                translateProc.buffer += data + "\n"
-            }
+            onRead: d => translateProc.buffer += d + "\n"
         }
         onStarted: {
             buffer = ""
             root.translatedText = ""
             root.secondTranslatedText = ""
         }
-        onExited: (exitCode, exitStatus) => {
-            const lines = buffer.trim().split(/\r?\n/).filter(l => l.length > 0)
-            if (!canTransliterate) {
-                root.translatedText = lines.join("\n")
-                root.secondTranslatedText = ""
-                return
+        onExited: () => {
+            const lines = buffer.trim().split(/\r?\n/).filter(Boolean)
+            if (!lines.length) return
+            const mid = lines.length >> 1
+            const tr = lines.slice(0, mid).join("\n").trim()
+            const tl = lines.slice(mid).join("\n").trim()
+            root.translatedText = tr
+            const has = tl.length > 0 && tl !== tr
+            if (!probeDone) {
+                probeDone = true
+                canTransliterate = has
+                if (!has) return
             }
-            const half = Math.floor(lines.length / 2)
-            const translationLines = lines.slice(0, half)
-            const transliterationLines = lines.slice(half)
-            root.translatedText = translationLines.join("\n")
-            root.secondTranslatedText = transliterationLines.join("\n")
+            root.secondTranslatedText = (canTransliterate && has) ? tl : ""
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
@@ -229,46 +229,40 @@ Item {
             "日本語","ಕನ್ನಡ","한국어","मराठी","پښتو","فارسی","ਪੰਜਾਬੀ","русский","தமிழ்",
             "తెలుగు","ไทย","اردو"
         ].includes(root.targetLanguage))
-        command: ["bash", "-c", `trans -brief -no-bidi` + ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'` + ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'` + ` '${StringUtils.shellSingleQuoteEscape(root.searchQuery.trim())}'`]
         property string buffer: ""
-        stdout: SplitParser {
-            onRead: data => {
-                translateProc.buffer += data + "\n";
-            }
-        }
-        onStarted: {
-            buffer = "";
-            root.translatedText = "";
-            root.secondTranslatedText = "";
-        }
-        onExited: (exitCode, exitStatus) => {
-            root.translatedText = translateProc.buffer.trim();
-            if (canTransliterate) {
-                secondProc.running = true;
-            }
-        }
-    }
-
-    // Second Process to get transliteration if supported
-    Process {
-        id: secondProc
-        property string secondBuffer: ""
         command: [
-            "bash",
-            "-c",
-            "trans -brief -no-bidi -source '" + StringUtils.shellSingleQuoteEscape(root.sourceLanguage) + "' -target '@" + StringUtils.shellSingleQuoteEscape(root.targetLanguage) + "' '" + StringUtils.shellSingleQuoteEscape(root.searchQuery.trim()) + "'"
+            "bash", "-c",
+            `trans -brief -no-bidi` +
+            ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'` +
+            (
+                canTransliterate
+                ? ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}+@${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
+                : ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
+            ) +
+            ` '${StringUtils.shellSingleQuoteEscape(root.searchQuery.trim())}'`
         ]
         stdout: SplitParser {
             onRead: data => {
-                secondProc.secondBuffer += data + "\n";
+                translateProc.buffer += data + "\n"
             }
         }
         onStarted: {
-            secondBuffer = "";
+            buffer = ""
+            root.translatedText = ""
+            root.secondTranslatedText = ""
         }
-        onExited: {
-            root.secondTranslatedText = secondBuffer.trim();
-            running = false;
+        onExited: (exitCode, exitStatus) => {
+            const lines = buffer.trim().split(/\r?\n/).filter(l => l.length > 0)
+            if (!canTransliterate) {
+                root.translatedText = lines.join("\n")
+                root.secondTranslatedText = ""
+                return
+            }
+            const half = Math.floor(lines.length / 2)
+            const translationLines = lines.slice(0, half)
+            const transliterationLines = lines.slice(half)
+            root.translatedText = translationLines.join("\n")
+            root.secondTranslatedText = transliterationLines.join("\n")
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
@@ -205,6 +205,9 @@ Item {
         translateTimer.restart();
         focusedControlIndex = -1;
     }
+    onTargetLanguageChanged: {
+        translateProc.canTransliterate = true
+    }
 
     Timer {
         id: translateTimer
@@ -224,18 +227,21 @@ Item {
 
     Process {
         id: translateProc
-        property bool probeDone: false
         property bool canTransliterate: true
         property string buffer: ""
+        function buildTarget() {
+            const s = StringUtils.shellSingleQuoteEscape
+            const tgt = s(root.targetLanguage)
+            return canTransliterate ? `${tgt}+@${tgt}` : tgt
+        }
         command: {
             const s = StringUtils.shellSingleQuoteEscape
             const src = s(root.sourceLanguage)
-            const tgt = s(root.targetLanguage)
+            const tgt = buildTarget()
             const inp = s(root.searchQuery.trim())
-            const t = canTransliterate ? `${tgt}+@${tgt}` : tgt
 
             return ["bash", "-c",
-                `trans -brief -no-bidi -source '${src}' -target '${t}' '${inp}'`
+                `trans -brief -no-bidi -source '${src}' -target '${tgt}' '${inp}'`
             ]
         }
         stdout: SplitParser {
@@ -253,13 +259,9 @@ Item {
             const tr = lines.slice(0, mid).join("\n").trim()
             const tl = lines.slice(mid).join("\n").trim()
             root.translatedText = tr
-            const has = tl.length > 0 && tl !== tr
-            if (!probeDone) {
-                probeDone = true
-                canTransliterate = has
-                if (!has) return
-            }
-            root.secondTranslatedText = (canTransliterate && has) ? tl : ""
+            const hasSecond = tl.length > 0 && tl !== tr
+            canTransliterate = hasSecond
+            root.secondTranslatedText = hasSecond ? tl : ""
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
@@ -232,6 +232,7 @@ Item {
         function buildTarget() {
             const s = StringUtils.shellSingleQuoteEscape
             const tgt = s(root.targetLanguage)
+            // If transliteration detected, return `language+@language`; else `language`
             return canTransliterate ? `${tgt}+@${tgt}` : tgt
         }
         command: {
@@ -253,14 +254,16 @@ Item {
             root.secondTranslatedText = ""
         }
         onExited: () => {
+            // Split output in half, first half is translation
             const lines = buffer.trim().split(/\r?\n/).filter(Boolean)
             if (!lines.length) return
             const mid = lines.length >> 1
             const tr = lines.slice(0, mid).join("\n").trim()
             const tl = lines.slice(mid).join("\n").trim()
             root.translatedText = tr
+            // If second half is unique, it is the transliteration
             const hasSecond = tl.length > 0 && tl !== tr
-            canTransliterate = hasSecond
+            translateProc.canTransliterate = hasSecond
             root.secondTranslatedText = hasSecond ? tl : ""
         }
     }

--- a/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/TranslatorPanel.qml
@@ -57,6 +57,7 @@ Item {
     }
 
     property string translatedText: ""
+    property string secondTranslatedText: ""
     property list<string> languages: []
     property bool showLanguageSelector: false
     property bool languageSelectorTarget: false // true for target, false for source
@@ -216,12 +217,18 @@ Item {
                 translateProc.running = true;
             } else {
                 root.translatedText = "";
+                root.secondTranslatedText = "";
             }
         }
     }
 
     Process {
         id: translateProc
+        property bool canTransliterate: ([
+            "العربية","বাংলা","भोजपुरी","简体中文","繁體中文","粵語","文言","ગુજરાતી","हिन्दी",
+            "日本語","ಕನ್ನಡ","한국어","मराठी","پښتو","فارسی","ਪੰਜਾਬੀ","русский","தமிழ்",
+            "తెలుగు","ไทย","اردو"
+        ].includes(root.targetLanguage))
         command: ["bash", "-c", `trans -brief -no-bidi` + ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'` + ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'` + ` '${StringUtils.shellSingleQuoteEscape(root.searchQuery.trim())}'`]
         property string buffer: ""
         stdout: SplitParser {
@@ -229,8 +236,39 @@ Item {
                 translateProc.buffer += data + "\n";
             }
         }
+        onStarted: {
+            buffer = "";
+            root.translatedText = "";
+            root.secondTranslatedText = "";
+        }
         onExited: (exitCode, exitStatus) => {
             root.translatedText = translateProc.buffer.trim();
+            if (canTransliterate) {
+                secondProc.running = true;
+            }
+        }
+    }
+
+    // Second Process to get transliteration if supported
+    Process {
+        id: secondProc
+        property string secondBuffer: ""
+        command: [
+            "bash",
+            "-c",
+            "trans -brief -no-bidi -source '" + StringUtils.shellSingleQuoteEscape(root.sourceLanguage) + "' -target '@" + StringUtils.shellSingleQuoteEscape(root.targetLanguage) + "' '" + StringUtils.shellSingleQuoteEscape(root.searchQuery.trim()) + "'"
+        ]
+        stdout: SplitParser {
+            onRead: data => {
+                secondProc.secondBuffer += data + "\n";
+            }
+        }
+        onStarted: {
+            secondBuffer = "";
+        }
+        onExited: {
+            root.secondTranslatedText = secondBuffer.trim();
+            running = false;
         }
     }
 
@@ -522,22 +560,100 @@ Item {
                     anchors.margins: 12
                     spacing: 8
 
-                    StyledFlickable {
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
-                        clip: true
-                        contentHeight: outputText.implicitHeight
+                StyledFlickable {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    Layout.minimumHeight: 0
+                    clip: true
 
+                    contentHeight: contentColumn.implicitHeight
+
+                    ColumnLayout {
+                        id: contentColumn
+                        width: parent.width
+                        spacing: 8
+
+                        // Main translated output
                         StyledText {
-                            id: outputText
-                            width: parent.width
+                            text: root.translatedText
+                            visible: text.length > 0
+
                             wrapMode: Text.Wrap
-                            text: root.translatedText !== "" ? root.translatedText : Translation.tr("Translation will appear here...")
-                            font.pixelSize: Appearance.font.pixelSize.normal
-                            color: root.translatedText !== "" ? colResultText : Appearance.colors.colSubtext
-                            opacity: root.translatedText !== "" ? 1.0 : 0.6
+                            font.pixelSize: Appearance.font.pixelSize.huge
+                            color: colResultText
+
+                            Layout.fillWidth: true
+                        }
+
+                        // Transliteration translated output
+                        Rectangle {
+                            id: transliterationBubble
+
+                            Layout.fillWidth: true
+                            visible: root.secondTranslatedText.length > 0
+                            
+                            opacity: visible ? 1 : 0
+                            Behavior on opacity { NumberAnimation { duration: 120 } }
+
+                            radius: Appearance.rounding.large
+                            color: Qt.darker(colResultBox, 1.8)
+
+                            implicitHeight: transliterationText.implicitHeight + 20
+                            property bool hovered: false
+
+                            HoverHandler {
+                                onHoveredChanged: transliterationBubble.hovered = hovered
+                            }
+
+                            StyledText {
+                                id: transliterationText
+
+                                text: root.secondTranslatedText
+                                wrapMode: Text.Wrap
+                                color: colResultText
+
+                                anchors {
+                                    top: parent.top
+                                    left: parent.left
+                                    right: parent.right
+                                    margins: 10
+                                    bottomMargin: 10
+                                }
+                            }
+
+                            // Copy button
+                            RippleButton {
+                                implicitWidth: 28
+                                implicitHeight: 28
+                                buttonRadius: Appearance.rounding.full
+
+                                anchors {
+                                    right: parent.right
+                                    bottom: parent.bottom
+                                    margins: 6
+                                }
+
+                                opacity: transliterationBubble.hovered ? 1.0 : 0.0
+                                visible: opacity > 0.01
+                                colBackground: pressed ? colBtnActive : (hovered ? colBtnHover : colBtn)
+                                Behavior on opacity { NumberAnimation { duration: 150 } }
+
+                                contentItem: Item {
+                                    anchors.fill: parent
+
+                                    MaterialSymbol {
+                                        anchors.centerIn: parent
+                                        text: "content_copy"
+                                        color: colIcon
+                                        font.pixelSize: 14
+                                    }
+                                }
+
+                                onClicked: Quickshell.clipboardText = root.secondTranslatedText
+                            }
                         }
                     }
+                }
 
                     // Right Bottom Actions Row
                     RowLayout {

--- a/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
@@ -369,12 +369,13 @@ Item {
 
                         // Main translated output
                         StyledText {
-                            text: root.translatedText
-                            visible: text.length > 0
+                            text: root.translatedText !== "" ? root.translatedText : Translation.tr("Translation will appear here...")
+                            visible: true
 
                             wrapMode: Text.Wrap
                             font.pixelSize: Appearance.font.pixelSize.huge
-                            color: colResultText
+                            color: root.translatedText !== "" ? colResultText : Appearance.colors.colSubtext
+                            opacity: root.translatedText !== "" ? 1.0 : 0.6
 
                             Layout.fillWidth: true
                         }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
@@ -100,45 +100,42 @@ Item {
 
     Process {
         id: translateProc
-        property bool canTransliterate: ([
-            "العربية","বাংলা","भोजपुरी","简体中文","繁體中文","粵語","文言","ગુજરાતી","हिन्दी",
-            "日本語","ಕನ್ನಡ","한국어","मराठी","پښتو","فارسی","ਪੰਜਾਬੀ","русский","தமிழ்",
-            "తెలుగు","ไทย","اردو"
-        ].includes(root.targetLanguage))
+        property bool probeDone: false
+        property bool canTransliterate: true
         property string buffer: ""
-        command: [
-            "bash", "-c",
-            `trans -brief -no-bidi` +
-            ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'` +
-            (
-                canTransliterate
-                ? ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}+@${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
-                : ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
-            ) +
-            ` '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`
-        ]
+        command: {
+            const s = StringUtils.shellSingleQuoteEscape
+            const src = s(root.sourceLanguage)
+            const tgt = s(root.targetLanguage)
+            const inp = s(root.inputField.text.trim())
+            const t = canTransliterate ? `${tgt}+@${tgt}` : tgt
+
+            return ["bash", "-c",
+                `trans -brief -no-bidi -source '${src}' -target '${t}' '${inp}'`
+            ]
+        }
         stdout: SplitParser {
-            onRead: data => {
-                translateProc.buffer += data + "\n"
-            }
+            onRead: d => translateProc.buffer += d + "\n"
         }
         onStarted: {
             buffer = ""
             root.translatedText = ""
             root.secondTranslatedText = ""
         }
-        onExited: (exitCode, exitStatus) => {
-            const lines = buffer.trim().split(/\r?\n/).filter(l => l.length > 0)
-            if (!canTransliterate) {
-                root.translatedText = lines.join("\n")
-                root.secondTranslatedText = ""
-                return
+        onExited: () => {
+            const lines = buffer.trim().split(/\r?\n/).filter(Boolean)
+            if (!lines.length) return
+            const mid = lines.length >> 1
+            const tr = lines.slice(0, mid).join("\n").trim()
+            const tl = lines.slice(mid).join("\n").trim()
+            root.translatedText = tr
+            const has = tl.length > 0 && tl !== tr
+            if (!probeDone) {
+                probeDone = true
+                canTransliterate = has
+                if (!has) return
             }
-            const half = Math.floor(lines.length / 2)
-            const translationLines = lines.slice(0, half)
-            const transliterationLines = lines.slice(half)
-            root.translatedText = translationLines.join("\n")
-            root.secondTranslatedText = transliterationLines.join("\n")
+            root.secondTranslatedText = (canTransliterate && has) ? tl : ""
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
@@ -108,6 +108,7 @@ Item {
         function buildTarget() {
             const s = StringUtils.shellSingleQuoteEscape
             const tgt = s(root.targetLanguage)
+            // If transliteration detected, return `language+@language`; else `language`
             return canTransliterate ? `${tgt}+@${tgt}` : tgt
         }
         command: {
@@ -129,14 +130,16 @@ Item {
             root.secondTranslatedText = ""
         }
         onExited: () => {
+            // Split output in half, first half is translation
             const lines = buffer.trim().split(/\r?\n/).filter(Boolean)
             if (!lines.length) return
             const mid = lines.length >> 1
             const tr = lines.slice(0, mid).join("\n").trim()
             const tl = lines.slice(mid).join("\n").trim()
             root.translatedText = tr
+            // If second half is unique, it is the transliteration
             const hasSecond = tl.length > 0 && tl !== tr
-            canTransliterate = hasSecond
+            translateProc.canTransliterate = hasSecond
             root.secondTranslatedText = hasSecond ? tl : ""
         }
     }

--- a/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
@@ -100,7 +100,6 @@ Item {
 
     Process {
         id: translateProc
-
         property bool canTransliterate: ([
             "العربية","বাংলা","भोजपुरी","简体中文","繁體中文","粵語","文言","ગુજરાતી","हिन्दी",
             "日本語","ಕನ್ನಡ","한국어","मराठी","پښتو","فارسی","ਪੰਜਾਬੀ","русский","தமிழ்",
@@ -109,7 +108,14 @@ Item {
         property string buffer: ""
         command: [
             "bash", "-c",
-            `trans -brief -no-bidi` + ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'` + ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'` + ` '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`
+            `trans -brief -no-bidi` +
+            ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'` +
+            (
+                canTransliterate
+                ? ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}+@${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
+                : ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
+            ) +
+            ` '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`
         ]
         stdout: SplitParser {
             onRead: data => {
@@ -122,33 +128,17 @@ Item {
             root.secondTranslatedText = ""
         }
         onExited: (exitCode, exitStatus) => {
-            root.translatedText = buffer.trim()
-
-            if (canTransliterate) {
-                secondProc.running = true
+            const lines = buffer.trim().split(/\r?\n/).filter(l => l.length > 0)
+            if (!canTransliterate) {
+                root.translatedText = lines.join("\n")
+                root.secondTranslatedText = ""
+                return
             }
-        }
-    }
-    
-    Process {
-        id: secondProc
-        property string secondBuffer: ""
-        command: [
-            "bash",
-            "-c",
-            `trans -brief -no-bidi -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}' -target '@${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}' '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`
-        ]
-        stdout: SplitParser {
-            onRead: data => {
-                secondProc.secondBuffer += data + "\n"
-            }
-        }
-        onStarted: {
-            secondBuffer = ""
-        }
-        onExited: {
-            root.secondTranslatedText = secondBuffer.trim()
-            running = false
+            const half = Math.floor(lines.length / 2)
+            const translationLines = lines.slice(0, half)
+            const transliterationLines = lines.slice(half)
+            root.translatedText = translationLines.join("\n")
+            root.secondTranslatedText = transliterationLines.join("\n")
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
@@ -81,6 +81,9 @@ Item {
             root.inputField.forceActiveFocus();
         }
     }
+    onTargetLanguageChanged: {
+        translateProc.canTransliterate = true
+    }
 
     Timer {
         id: translateTimer
@@ -100,18 +103,21 @@ Item {
 
     Process {
         id: translateProc
-        property bool probeDone: false
         property bool canTransliterate: true
         property string buffer: ""
+        function buildTarget() {
+            const s = StringUtils.shellSingleQuoteEscape
+            const tgt = s(root.targetLanguage)
+            return canTransliterate ? `${tgt}+@${tgt}` : tgt
+        }
         command: {
             const s = StringUtils.shellSingleQuoteEscape
             const src = s(root.sourceLanguage)
-            const tgt = s(root.targetLanguage)
+            const tgt = buildTarget()
             const inp = s(root.inputField.text.trim())
-            const t = canTransliterate ? `${tgt}+@${tgt}` : tgt
 
             return ["bash", "-c",
-                `trans -brief -no-bidi -source '${src}' -target '${t}' '${inp}'`
+                `trans -brief -no-bidi -source '${src}' -target '${tgt}' '${inp}'`
             ]
         }
         stdout: SplitParser {
@@ -129,13 +135,9 @@ Item {
             const tr = lines.slice(0, mid).join("\n").trim()
             const tl = lines.slice(mid).join("\n").trim()
             root.translatedText = tr
-            const has = tl.length > 0 && tl !== tr
-            if (!probeDone) {
-                probeDone = true
-                canTransliterate = has
-                if (!has) return
-            }
-            root.secondTranslatedText = (canTransliterate && has) ? tl : ""
+            const hasSecond = tl.length > 0 && tl !== tr
+            canTransliterate = hasSecond
+            root.secondTranslatedText = hasSecond ? tl : ""
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
@@ -51,6 +51,7 @@ Item {
     // Widget variables
     property bool translationFor: false // Indicates if the translation is for an autocorrected text
     property string translatedText: ""
+    property string secondTranslatedText: ""
     property list<string> languages: []
 
     // Options
@@ -92,21 +93,62 @@ Item {
                 translateProc.running = true; // Restart the process
             } else {
                 root.translatedText = "";
+                root.secondTranslatedText = "";
             }
         }
     }
 
     Process {
         id: translateProc
-        command: ["bash", "-c", `trans -brief -no-bidi` + ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'` + ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'` + ` '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`]
+
+        property bool canTransliterate: ([
+            "العربية","বাংলা","भोजपुरी","简体中文","繁體中文","粵語","文言","ગુજરાતી","हिन्दी",
+            "日本語","ಕನ್ನಡ","한국어","मराठी","پښتو","فارسی","ਪੰਜਾਬੀ","русский","தமிழ்",
+            "తెలుగు","ไทย","اردو"
+        ].includes(root.targetLanguage))
         property string buffer: ""
+        command: [
+            "bash", "-c",
+            `trans -brief -no-bidi` + ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'` + ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'` + ` '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`
+        ]
         stdout: SplitParser {
             onRead: data => {
-                translateProc.buffer += data + "\n";
+                translateProc.buffer += data + "\n"
             }
         }
+        onStarted: {
+            buffer = ""
+            root.translatedText = ""
+            root.secondTranslatedText = ""
+        }
         onExited: (exitCode, exitStatus) => {
-            root.translatedText = translateProc.buffer.trim();
+            root.translatedText = buffer.trim()
+
+            if (canTransliterate) {
+                secondProc.running = true
+            }
+        }
+    }
+    
+    Process {
+        id: secondProc
+        property string secondBuffer: ""
+        command: [
+            "bash",
+            "-c",
+            `trans -brief -no-bidi -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}' -target '@${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}' '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`
+        ]
+        stdout: SplitParser {
+            onRead: data => {
+                secondProc.secondBuffer += data + "\n"
+            }
+        }
+        onStarted: {
+            secondBuffer = ""
+        }
+        onExited: {
+            root.secondTranslatedText = secondBuffer.trim()
+            running = false
         }
     }
 
@@ -323,16 +365,95 @@ Item {
                 StyledFlickable {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
+                    Layout.minimumHeight: 0
                     clip: true
-                    contentHeight: outputText.implicitHeight
 
-                    StyledText {
-                        id: outputText
+                    contentHeight: contentColumn.implicitHeight
+
+                    ColumnLayout {
+                        id: contentColumn
                         width: parent.width
-                        wrapMode: Text.Wrap
-                        text: root.translatedText
-                        font.pixelSize: Appearance.font.pixelSize.huge // Material 3 Expressive
-                        color: colResultText
+                        spacing: 8
+
+                        // Main translated output
+                        StyledText {
+                            text: root.translatedText
+                            visible: text.length > 0
+
+                            wrapMode: Text.Wrap
+                            font.pixelSize: Appearance.font.pixelSize.huge
+                            color: colResultText
+
+                            Layout.fillWidth: true
+                        }
+
+                        // Transliteration translated output
+                        Rectangle {
+                            id: transliterationBubble
+
+                            Layout.fillWidth: true
+                            visible: root.secondTranslatedText.length > 0
+                            
+                            opacity: visible ? 1 : 0
+                            Behavior on opacity { NumberAnimation { duration: 120 } }
+
+                            radius: Appearance.rounding.large
+                            color: Qt.darker(colResultBox, 1.8)
+
+                            implicitHeight: transliterationText.implicitHeight + 20
+                            property bool hovered: false
+
+                            HoverHandler {
+                                onHoveredChanged: transliterationBubble.hovered = hovered
+                            }
+
+                            StyledText {
+                                id: transliterationText
+
+                                text: root.secondTranslatedText
+                                wrapMode: Text.Wrap
+                                color: colResultText
+
+                                anchors {
+                                    top: parent.top
+                                    left: parent.left
+                                    right: parent.right
+                                    margins: 10
+                                    bottomMargin: 10
+                                }
+                            }
+
+                            // Copy button
+                            RippleButton {
+                                implicitWidth: 28
+                                implicitHeight: 28
+                                buttonRadius: Appearance.rounding.full
+
+                                anchors {
+                                    right: parent.right
+                                    bottom: parent.bottom
+                                    margins: 6
+                                }
+
+                                opacity: transliterationBubble.hovered ? 1.0 : 0.0
+                                visible: opacity > 0.01
+                                colBackground: pressed ? colResultActionBtnActive : (hovered ? colResultActionBtnHover : colResultActionBtn)
+                                Behavior on opacity { NumberAnimation { duration: 150 } }
+
+                                contentItem: Item {
+                                    anchors.fill: parent
+
+                                    MaterialSymbol {
+                                        anchors.centerIn: parent
+                                        text: "content_copy"
+                                        color: colResultActionIcon
+                                        font.pixelSize: 14
+                                    }
+                                }
+
+                                onClicked: Quickshell.clipboardText = root.secondTranslatedText
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
Adds support for displaying transliteration alongside translated text when using languages that provide transliteration data.

A button to copy the transliteration appears when hovering over the transliteration field.

<img width="699" height="472" alt="image" src="https://github.com/user-attachments/assets/ec489e14-6848-454c-b02f-889eebb0af6c" />

<img width="324" height="332" alt="image" src="https://github.com/user-attachments/assets/8c8fce32-dec0-4c1a-99b0-6d3f1631f17a" />