### PR TITLE
feat: add multi-timezone clock to time popup

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -1049,6 +1049,7 @@ Singleton {
                     property int focus: 1500
                     property int longBreak: 900
                 }
+                property list<var> worldClocks: []
                 property bool secondPrecision: false
             }
 

--- a/dots/.config/quickshell/ii/modules/ii/bar/ClockWidgetPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ClockWidgetPopup.qml
@@ -4,10 +4,77 @@ import "./cards"
 import qs.services
 import QtQuick
 import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
 
 StyledPopup {
     id: root
     popupRadius: Appearance.rounding.large
+
+    property var timezoneOffsets: ({})
+    property var worldClocksOption: Config.options.time.worldClocks
+    onWorldClocksOptionChanged: {
+        root.refreshTimezoneOffsets();
+    }
+
+    function refreshTimezoneOffsets() {
+        let timezones = Config.options.time.worldClocks || [];
+        if (timezones.length === 0) {
+            root.timezoneOffsets = {};
+            return;
+        }
+
+        let script = "";
+        for (let i = 0; i < timezones.length; i++) {
+            let tz = timezones[i].tz;
+            if (tz) {
+                let safeTz = tz.replace(/'/g, "'\\''");
+                script += `TZ='${safeTz}' date +'%H:%M %z %Z ${safeTz}'; `;
+            }
+        }
+
+        if (script === "") {
+            root.timezoneOffsets = {};
+            return;
+        }
+
+        _worldClocksProcess.offsetFetcher.command = ["bash", "-c", script];
+        _worldClocksProcess.offsetFetcher.running = true;
+    }
+
+    property QtObject _worldClocksProcess: QtObject {
+        property Process offsetFetcher: Process {
+            stdout: StdioCollector {
+                id: offsetCollector
+                onStreamFinished: {
+                    let lines = offsetCollector.text.split("\n");
+                    let newOffsets = {};
+                    for (let i = 0; i < lines.length; i++) {
+                        let line = lines[i].trim();
+                        if (!line) continue;
+                        let parts = line.split(" ");
+                        if (parts.length >= 4) {
+                            let timeStr = parts[0];
+                            let offsetStr = parts[1];
+                            let tzName = parts[2];
+                            let tz = parts.slice(3).join(" ");
+
+                            let sign = offsetStr.charAt(0) === "-" ? -1 : 1;
+                            let hours = parseInt(offsetStr.substring(1, 3));
+                            let mins = parseInt(offsetStr.substring(3, 5));
+                            let offsetMins = sign * (hours * 60 + mins);
+
+                            newOffsets[tz] = {
+                                offsetMins: offsetMins,
+                                tzName: tzName
+                            };
+                        }
+                    }
+                    root.timezoneOffsets = newOffsets;
+                }
+            }
+        }
+    }
 
     required property bool compact
     property string formattedDate: Qt.locale().toString(DateTime.clock.date, "MMMM dd, dddd")
@@ -51,6 +118,103 @@ StyledPopup {
         const secondsPassed = date.getHours() * 3600 + date.getMinutes() * 60 +date.getSeconds()
 
         return Math.floor((secondsPassed / 86400) * 100)
+    }
+
+    function getUtcTimeForTz(tz, date) {
+        try {
+            const data = root.timezoneOffsets[tz];
+            if (!data) return NaN;
+            return date.getTime() + (data.offsetMins * 60000);
+        } catch (e) {
+            return NaN;
+        }
+    }
+
+    function getTimezoneOffsetString(tz, date) {
+        try {
+            const data = root.timezoneOffsets[tz];
+            if (!data) return "";
+
+            const localOffsetMins = -date.getTimezoneOffset();
+            const targetOffsetMins = data.offsetMins;
+
+            const diffMins = targetOffsetMins - localOffsetMins;
+            if (diffMins === 0) {
+                return "";
+            }
+
+            const diffHrs = diffMins / 60;
+            const sign = diffHrs > 0 ? "+" : "";
+
+            if (diffMins % 60 === 0) {
+                return sign + diffHrs + "h";
+            }
+
+            const hrs = Math.floor(Math.abs(diffMins) / 60);
+            const mins = Math.abs(diffMins) % 60;
+            return `${sign}${diffHrs < 0 ? "-" : ""}${hrs}h ${mins}m`;
+        } catch (e) {
+            return "";
+        }
+    }
+
+    function getFormattedTime(tz, date) {
+        try {
+            const data = root.timezoneOffsets[tz];
+            if (!data) return "--:--";
+
+            const offsetMins = data.offsetMins;
+            const targetDate = new Date(date.getTime() + (offsetMins * 60000));
+
+            const formatStr = Config.options?.time?.format ?? "hh:mm";
+            const use12h = formatStr.includes("ap") || formatStr.includes("AP");
+            const showSeconds = Config.options?.time?.secondPrecision ?? false;
+
+            let hour = targetDate.getUTCHours();
+            let minute = targetDate.getUTCMinutes();
+            let second = targetDate.getUTCSeconds();
+
+            let ampm = "";
+            if (use12h) {
+                ampm = hour >= 12 ? (formatStr.includes("AP") ? " PM" : " pm") : (formatStr.includes("AP") ? " AM" : " am");
+                hour = hour % 12 || 12;
+            }
+
+            let hrStr = String(hour).padStart(2, "0");
+            let minStr = String(minute).padStart(2, "0");
+            let secStr = showSeconds ? ":" + String(second).padStart(2, "0") : "";
+
+            return hrStr + ":" + minStr + secStr + ampm;
+        } catch (e) {
+            return "--:--";
+        }
+    }
+
+    function getFormattedDate(tz, date) {
+        try {
+            const data = root.timezoneOffsets[tz];
+            if (!data) return "";
+
+            const offsetMins = data.offsetMins;
+            const targetDate = new Date(date.getTime() + (offsetMins * 60000));
+
+            const dateFormatStr = Config.options?.time?.dateFormat ?? "ddd dd/MM";
+            const showMonthFirst = dateFormatStr.includes("MM/dd");
+
+            const days = [Translation.tr("Sun"), Translation.tr("Mon"), Translation.tr("Tue"), Translation.tr("Wed"), Translation.tr("Thu"), Translation.tr("Fri"), Translation.tr("Sat")];
+            const weekday = days[targetDate.getUTCDay()];
+
+            const day = String(targetDate.getUTCDate()).padStart(2, "0");
+            const month = String(targetDate.getUTCMonth() + 1).padStart(2, "0");
+
+            if (showMonthFirst) {
+                return `${weekday} ${month}/${day}`;
+            } else {
+                return `${weekday} ${day}/${month}`;
+            }
+        } catch (e) {
+            return "";
+        }
     }
 
     contentItem: ColumnLayout {
@@ -182,6 +346,14 @@ StyledPopup {
         }
 
         Loader {
+            id: worldClocksLoader
+            Layout.fillWidth: true
+            visible: active
+            active: Config.options.time.worldClocks && Config.options.time.worldClocks.length > 0
+            sourceComponent: worldClocksComponent
+        }
+
+        Loader {
             Layout.fillWidth: true
             visible: active
             active: root.compact ? sourceComponent !== todoSection : true
@@ -200,6 +372,99 @@ StyledPopup {
                     visible: root.todosEmpty
                     loading: false
                     emptyText: Translation.tr("No pending tasks")
+                }
+            }
+        }
+
+        Component {
+            id: worldClocksComponent
+            SectionCard {
+                title: Translation.tr("World Clocks")
+                icon: "public"
+                showDivider: true
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 10
+
+                    Repeater {
+                        model: Config.options.time.worldClocks
+
+                        RowLayout {
+                            id: clockRow
+                            Layout.fillWidth: true
+                            spacing: 12
+
+                            required property var modelData
+                            required property int index
+
+                            ColumnLayout {
+                                spacing: 2
+
+                                StyledText {
+                                    text: clockRow.modelData.name || clockRow.modelData.tz || Translation.tr("Unnamed")
+                                    font.weight: Font.Bold
+                                    font.pixelSize: Appearance.font.pixelSize.normal
+                                    color: Appearance.colors.colOnSurface
+                                }
+
+                                StyledText {
+                                    text: {
+                                        let offset = root.getTimezoneOffsetString(clockRow.modelData.tz, DateTime.clock.date);
+                                        if (offset === "") {
+                                            return Translation.tr("Same time");
+                                        }
+                                        return offset + " " + Translation.tr("relative to local");
+                                    }
+                                    font.pixelSize: Appearance.font.pixelSize.small
+                                    color: Appearance.colors.colSubtext
+                                }
+                            }
+
+                            Item {
+                                Layout.fillWidth: true
+                            }
+
+                            ColumnLayout {
+                                spacing: 2
+                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+
+                                StyledText {
+                                    text: root.getFormattedTime(clockRow.modelData.tz, DateTime.clock.date)
+                                    font.weight: Font.Bold
+                                    font.pixelSize: Appearance.font.pixelSize.normal
+                                    color: Appearance.colors.colOnSurface
+                                    Layout.alignment: Qt.AlignRight
+                                }
+
+                                StyledText {
+                                    text: root.getFormattedDate(clockRow.modelData.tz, DateTime.clock.date)
+                                    font.pixelSize: Appearance.font.pixelSize.small
+                                    color: Appearance.colors.colSubtext
+                                    Layout.alignment: Qt.AlignRight
+                                }
+                            }
+
+                            MaterialSymbol {
+                                text: {
+                                    try {
+                                        const targetUtc = root.getUtcTimeForTz(clockRow.modelData.tz, DateTime.clock.date);
+                                        if (isNaN(targetUtc)) {
+                                            return "question_mark";
+                                        }
+                                        const targetDate = new Date(targetUtc);
+                                        const hour = targetDate.getUTCHours();
+                                        return (hour < 6 || hour >= 18) ? "dark_mode" : "light_mode";
+                                    } catch (e) {
+                                        return "question_mark";
+                                    }
+                                }
+                                iconSize: 20
+                                color: text === "light_mode" ? Appearance.colors.colPrimary : Appearance.colors.colSubtext
+                                Layout.alignment: Qt.AlignVCenter
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/dots/.config/quickshell/ii/modules/ii/bar/ClockWidgetPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ClockWidgetPopup.qml
@@ -79,7 +79,6 @@ StyledPopup {
     required property bool compact
     property string formattedDate: Qt.locale().toString(DateTime.clock.date, "MMMM dd, dddd")
     property string formattedTime: DateTime.time
-    property string formattedUptime: DateTime.uptime
     property string todosSection: getUpcomingTodos(Todo.list)
     property bool todosEmpty: todosSection === ""
     stickyHover: true
@@ -237,20 +236,6 @@ StyledPopup {
         ColumnLayout {
             Layout.fillWidth: true
             spacing: 12
-
-            InfoPill {
-                visible: !root.compact ? LocalSend.currentTransfer == null || LocalSend.droppedFiles.length > 0 : false
-                text: root.formattedUptime
-
-                shapeContent: CustomIcon {
-                    anchors.centerIn: parent
-                    width: 24
-                    height: 24
-                    source: SystemInfo.distroIcon
-                    colorize: true
-                    color: Appearance.colors.colOnSecondary
-                }
-            }
 
             InfoPill {
                 visible: !root.compact ? LocalSend.currentTransfer == null || LocalSend.droppedFiles.length > 0 : false

--- a/dots/.config/quickshell/ii/modules/settings/GeneralConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/GeneralConfig.qml
@@ -564,6 +564,105 @@ ContentPage {
                 ]
             }
         }
+
+        ContentSubsection {
+            id: worldClocksSubsection
+            title: Translation.tr("World Clocks")
+            tooltip: Translation.tr("Manage timezones displayed in the clock widget popup")
+            Layout.fillWidth: true
+
+            function addWorldClock() {
+                let list = [];
+                if (Config.options.time.worldClocks) {
+                    for (let i = 0; i < Config.options.time.worldClocks.length; i++) {
+                        list.push(Config.options.time.worldClocks[i]);
+                    }
+                }
+                list.push({ "name": "", "tz": "" });
+                Config.options.time.worldClocks = list;
+            }
+
+            function removeWorldClock(index) {
+                let list = [];
+                for (let i = 0; i < Config.options.time.worldClocks.length; i++) {
+                    if (i !== index) {
+                        list.push(Config.options.time.worldClocks[i]);
+                    }
+                }
+                Config.options.time.worldClocks = list;
+            }
+
+            function updateWorldClock(index, key, value) {
+                let list = [];
+                for (let i = 0; i < Config.options.time.worldClocks.length; i++) {
+                    let item = Config.options.time.worldClocks[i];
+                    if (i === index) {
+                        let newItem = { "name": item.name, "tz": item.tz };
+                        newItem[key] = value;
+                        list.push(newItem);
+                    } else {
+                        list.push(item);
+                    }
+                }
+                Config.options.time.worldClocks = list;
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Repeater {
+                    model: Config.options.time.worldClocks
+
+                    RowLayout {
+                        id: clockRow
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        required property var modelData
+                        required property int index
+
+                        MaterialTextField {
+                            Layout.fillWidth: true
+                            placeholderText: Translation.tr("City Name (e.g. New York)")
+                            text: clockRow.modelData.name
+                            onEditingFinished: {
+                                if (text !== clockRow.modelData.name) {
+                                    worldClocksSubsection.updateWorldClock(clockRow.index, "name", text);
+                                }
+                            }
+                        }
+
+                        MaterialTextField {
+                            Layout.fillWidth: true
+                            placeholderText: Translation.tr("Timezone ID (e.g. America/New_York)")
+                            text: clockRow.modelData.tz
+                            onEditingFinished: {
+                                if (text !== clockRow.modelData.tz) {
+                                    worldClocksSubsection.updateWorldClock(clockRow.index, "tz", text);
+                                }
+                            }
+                        }
+
+                        IconToolbarButton {
+                            text: "delete"
+                            onClicked: {
+                                worldClocksSubsection.removeWorldClock(clockRow.index);
+                            }
+                        }
+                    }
+                }
+
+                RippleButtonWithIcon {
+                    Layout.fillWidth: true
+                    materialIcon: "add"
+                    mainText: Translation.tr("Add World Clock")
+                    onClicked: {
+                        worldClocksSubsection.addWorldClock();
+                    }
+                }
+            }
+        }
     }
 
     ContentSection {

--- a/dots/.config/quickshell/ii/modules/settings/GeneralConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/GeneralConfig.qml
@@ -618,6 +618,7 @@ ContentPage {
                         required property var modelData
                         required property int index
                         property bool searchFailed: false
+                        property bool isSearching: false
 
                         Process {
                             id: tzSearchProc
@@ -629,8 +630,10 @@ ContentPage {
                             onStarted: {
                                 buffer = "";
                                 clockRow.searchFailed = false;
+                                clockRow.isSearching = true;
                             }
                             onExited: {
+                                clockRow.isSearching = false;
                                 let res = buffer.trim();
                                 if (res) {
                                     worldClocksSubsection.updateWorldClock(clockRow.index, "tz", res);
@@ -649,9 +652,13 @@ ContentPage {
                             spacing: 8
 
                             MaterialTextField {
+                                id: cityField
                                 Layout.fillWidth: true
+                                Layout.preferredHeight: 40
+                                Layout.minimumWidth: 80
                                 placeholderText: Translation.tr("City Name (e.g. Tokyo)")
                                 text: clockRow.modelData.name || ""
+                                wrapMode: TextEdit.NoWrap
                                 onEditingFinished: {
                                     if (text !== (clockRow.modelData.name || "")) {
                                         worldClocksSubsection.updateWorldClock(clockRow.index, "name", text);
@@ -662,27 +669,64 @@ ContentPage {
                                 }
                             }
 
-                            MaterialTextField {
-                                Layout.fillWidth: true
-                                placeholderText: Translation.tr("Timezone ID (e.g. Asia/Tokyo)")
-                                text: clockRow.modelData.tz || ""
-                                onEditingFinished: {
-                                    if (text !== (clockRow.modelData.tz || "")) {
-                                        worldClocksSubsection.updateWorldClock(clockRow.index, "tz", text);
-                                    }
+                            // Timezone chip (visible when detected)
+                            Rectangle {
+                                visible: (clockRow.modelData.tz || "") !== "" && !clockRow.searchFailed
+                                Layout.preferredHeight: 36
+                                Layout.preferredWidth: Math.max(tzChipText.implicitWidth + 16, 60)
+                                color: Appearance.colors.colSurfaceContainerHigh
+                                radius: Appearance.rounding.full
+
+                                StyledText {
+                                    id: tzChipText
+                                    anchors.centerIn: parent
+                                    text: clockRow.modelData.tz || ""
+                                    font.pixelSize: Appearance.font.pixelSize.small
+                                    color: Appearance.colors.colOnSurfaceVariant
+                                    elide: Text.ElideRight
+                                    width: parent.width - 16
                                 }
+                            }
+
+                            MaterialLoadingIndicator {
+                                loading: true
+                                visible: clockRow.isSearching
+                                Layout.preferredHeight: 24
+                                Layout.preferredWidth: 24
                             }
 
                             IconToolbarButton {
                                 text: "search"
+                                Layout.preferredHeight: 36
+                                Layout.preferredWidth: 36
+                                enabled: (clockRow.modelData.tz || "") === "" && !clockRow.isSearching
                                 onClicked: tzSearchProc.running = true
                                 StyledToolTip { text: Translation.tr("Auto-detect Timezone from City Name") }
                             }
 
                             IconToolbarButton {
                                 text: "delete"
+                                Layout.preferredHeight: 36
+                                Layout.preferredWidth: 36
                                 onClicked: {
                                     worldClocksSubsection.removeWorldClock(clockRow.index);
+                                }
+                            }
+                        }
+
+                        // Fallback manual timezone field
+                        MaterialTextField {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 40
+                            Layout.minimumWidth: 80
+                            visible: clockRow.searchFailed
+                            placeholderText: Translation.tr("Timezone ID (e.g. Asia/Tokyo)")
+                            text: clockRow.modelData.tz || ""
+                            wrapMode: TextEdit.NoWrap
+                            onEditingFinished: {
+                                if (text !== (clockRow.modelData.tz || "")) {
+                                    worldClocksSubsection.updateWorldClock(clockRow.index, "tz", text);
+                                    clockRow.searchFailed = false;
                                 }
                             }
                         }
@@ -691,7 +735,7 @@ ContentPage {
                             Layout.leftMargin: 8
                             Layout.bottomMargin: 4
                             visible: clockRow.searchFailed
-                            text: Translation.tr("Timezone not found for '%1'. Try a different name.").arg(clockRow.modelData.name || "")
+                            text: Translation.tr("Timezone not found for '%1'. Try a different name or enter the ID manually.").arg(clockRow.modelData.name || "")
                             color: Appearance.colors.colError
                             font.pixelSize: Appearance.font.pixelSize.smaller
                         }

--- a/dots/.config/quickshell/ii/modules/settings/GeneralConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/GeneralConfig.qml
@@ -572,32 +572,28 @@ ContentPage {
             Layout.fillWidth: true
 
             function addWorldClock() {
-                let list = [];
-                if (Config.options.time.worldClocks) {
-                    for (let i = 0; i < Config.options.time.worldClocks.length; i++) {
-                        list.push(Config.options.time.worldClocks[i]);
-                    }
-                }
+                let list = Config.options.time.worldClocks ? Array.from(Config.options.time.worldClocks) : [];
                 list.push({ "name": "", "tz": "" });
                 Config.options.time.worldClocks = list;
             }
 
             function removeWorldClock(index) {
-                let list = [];
-                for (let i = 0; i < Config.options.time.worldClocks.length; i++) {
-                    if (i !== index) {
-                        list.push(Config.options.time.worldClocks[i]);
-                    }
+                let list = Config.options.time.worldClocks ? Array.from(Config.options.time.worldClocks) : [];
+                if (index >= 0 && index < list.length) {
+                    list.splice(index, 1);
+                    Config.options.time.worldClocks = list;
                 }
-                Config.options.time.worldClocks = list;
             }
 
             function updateWorldClock(index, key, value) {
+                let current = Config.options.time.worldClocks || [];
+                if (index < 0 || index >= current.length) return;
+                
                 let list = [];
-                for (let i = 0; i < Config.options.time.worldClocks.length; i++) {
-                    let item = Config.options.time.worldClocks[i];
+                for (let i = 0; i < current.length; i++) {
+                    let item = current[i] || { "name": "", "tz": "" };
                     if (i === index) {
-                        let newItem = { "name": item.name, "tz": item.tz };
+                        let newItem = { "name": item.name || "", "tz": item.tz || "" };
                         newItem[key] = value;
                         list.push(newItem);
                     } else {
@@ -614,41 +610,90 @@ ContentPage {
                 Repeater {
                     model: Config.options.time.worldClocks
 
-                    RowLayout {
+                    ColumnLayout {
                         id: clockRow
                         Layout.fillWidth: true
-                        spacing: 8
+                        spacing: 2
 
                         required property var modelData
                         required property int index
+                        property bool searchFailed: false
 
-                        MaterialTextField {
-                            Layout.fillWidth: true
-                            placeholderText: Translation.tr("City Name (e.g. New York)")
-                            text: clockRow.modelData.name
-                            onEditingFinished: {
-                                if (text !== clockRow.modelData.name) {
-                                    worldClocksSubsection.updateWorldClock(clockRow.index, "name", text);
+                        Process {
+                            id: tzSearchProc
+                            command: ["bash", "-c", "QUERY=$(echo '" + (clockRow.modelData.name || "").replace(/'/g, "'\\''").replace(/ /g, "_") + "' | iconv -f UTF-8 -t ASCII//TRANSLIT | sed 's/[^a-zA-Z0-9_]//g'); [ -n \"$QUERY\" ] && timedatectl list-timezones | grep -i \"$QUERY\" | head -n 1 || true"]
+                            property string buffer: ""
+                            stdout: SplitParser {
+                                onRead: data => tzSearchProc.buffer += data
+                            }
+                            onStarted: {
+                                buffer = "";
+                                clockRow.searchFailed = false;
+                            }
+                            onExited: {
+                                let res = buffer.trim();
+                                if (res) {
+                                    worldClocksSubsection.updateWorldClock(clockRow.index, "tz", res);
+                                    let prettyName = res.split("/").pop().replace(/_/g, " ");
+                                    if ((clockRow.modelData.name || "") === "" || clockRow.modelData.name.toLowerCase() === prettyName.toLowerCase()) {
+                                        worldClocksSubsection.updateWorldClock(clockRow.index, "name", prettyName);
+                                    }
+                                } else {
+                                    clockRow.searchFailed = true;
                                 }
                             }
                         }
 
-                        MaterialTextField {
+                        RowLayout {
                             Layout.fillWidth: true
-                            placeholderText: Translation.tr("Timezone ID (e.g. America/New_York)")
-                            text: clockRow.modelData.tz
-                            onEditingFinished: {
-                                if (text !== clockRow.modelData.tz) {
-                                    worldClocksSubsection.updateWorldClock(clockRow.index, "tz", text);
+                            spacing: 8
+
+                            MaterialTextField {
+                                Layout.fillWidth: true
+                                placeholderText: Translation.tr("City Name (e.g. Tokyo)")
+                                text: clockRow.modelData.name || ""
+                                onEditingFinished: {
+                                    if (text !== (clockRow.modelData.name || "")) {
+                                        worldClocksSubsection.updateWorldClock(clockRow.index, "name", text);
+                                        if ((clockRow.modelData.tz || "") === "") {
+                                            tzSearchProc.running = true;
+                                        }
+                                    }
+                                }
+                            }
+
+                            MaterialTextField {
+                                Layout.fillWidth: true
+                                placeholderText: Translation.tr("Timezone ID (e.g. Asia/Tokyo)")
+                                text: clockRow.modelData.tz || ""
+                                onEditingFinished: {
+                                    if (text !== (clockRow.modelData.tz || "")) {
+                                        worldClocksSubsection.updateWorldClock(clockRow.index, "tz", text);
+                                    }
+                                }
+                            }
+
+                            IconToolbarButton {
+                                text: "search"
+                                onClicked: tzSearchProc.running = true
+                                StyledToolTip { text: Translation.tr("Auto-detect Timezone from City Name") }
+                            }
+
+                            IconToolbarButton {
+                                text: "delete"
+                                onClicked: {
+                                    worldClocksSubsection.removeWorldClock(clockRow.index);
                                 }
                             }
                         }
 
-                        IconToolbarButton {
-                            text: "delete"
-                            onClicked: {
-                                worldClocksSubsection.removeWorldClock(clockRow.index);
-                            }
+                        StyledText {
+                            Layout.leftMargin: 8
+                            Layout.bottomMargin: 4
+                            visible: clockRow.searchFailed
+                            text: Translation.tr("Timezone not found for '%1'. Try a different name.").arg(clockRow.modelData.name || "")
+                            color: Appearance.colors.colError
+                            font.pixelSize: Appearance.font.pixelSize.smaller
                         }
                     }
                 }


### PR DESCRIPTION
## Describe your changes

Added a multi-timezone clock on the time popup configurable on the General --> Time section using IANA Timezone ID (e.g. `Europe/Paris` `America/New_York` `Asia/Tokyo`)

<img width="303.5" height="560" alt="image" src="https://github.com/user-attachments/assets/d1d6a337-a971-46fa-b386-2c7ac20a5fe8" />


## Is it ready? Questions/feedback needed?

Ready, or at least should be