### PR TITLE
fix(battery): show exact battery cycles from sysfs and fallback to estimation

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/BatteryPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BatteryPopup.qml
@@ -314,9 +314,14 @@ StyledPopup {
                         }
 
                         StyledText {
-                            text: Battery.health > 0
-                                  ? `~${Math.round((100 - Battery.health) * 10)}`
-                                  : "--"
+                            text: {
+                                if (Battery.cycles >= 0) {
+                                    return Battery.cycles.toString();
+                                }
+                                return Battery.health > 0
+                                      ? `~${Math.round((100 - Battery.health) * 10)}`
+                                      : "--";
+                            }
                             font.pixelSize: Appearance.font.pixelSize.normal
                             font.weight: Font.Bold
                             color: Appearance.colors.colOnSurface

--- a/dots/.config/quickshell/ii/services/Battery.qml
+++ b/dots/.config/quickshell/ii/services/Battery.qml
@@ -49,6 +49,43 @@ Singleton {
         return 0;
     })()
 
+    property string batteryNativePath: {
+        const devList = UPower.devices.values;
+        for (let i = 0; i < devList.length; ++i) {
+            const dev = devList[i];
+            if (dev.isLaptopBattery) {
+                return dev.nativePath;
+            }
+        }
+        return "";
+    }
+
+    property int cycles: -1
+
+    FileView {
+        id: cycleCountFile
+        path: root.batteryNativePath ? `/sys/class/power_supply/${root.batteryNativePath}/cycle_count` : ""
+        onLoaded: {
+            const content = text().trim();
+            const val = parseInt(content, 10);
+            if (!isNaN(val)) {
+                root.cycles = val;
+            } else {
+                root.cycles = -1;
+            }
+        }
+        onLoadFailed: {
+            root.cycles = -1;
+        }
+    }
+
+    onBatteryNativePathChanged: {
+        cycleCountFile.reload();
+    }
+
+    onChargeStateChanged: {
+        cycleCountFile.reload();
+    }
 
     onIsLowAndNotChargingChanged: {
         if (!root.available || !isLowAndNotCharging) return;


### PR DESCRIPTION
## Describe your changes

Fixed the charge cycle count on the battery popup
It now retrieves the charge cycle count from `/sys/class/power_supply/<nativePath>/cycle_count` instead of just estimating it from the battery health
`nativePath` is found using the `UPower.devices` list
If charge cycle cannot be retrieved, it fallback to previous estimation method

Also changed to reload the cycle count only when the battery charge state changes (plugging/unplugging/full) to minimize unnecessary disk reads

## Is it ready? Questions/feedback needed?

Works on local but I only have one laptop to test it on so I'd like some confirmation it doesn't only work on my laptop