### PR TITLE
feat(bar): sync active window widget animation with dynamic island

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/ActiveWindow.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ActiveWindow.qml
@@ -33,10 +33,16 @@ Item {
     clip: true
 
     Behavior on implicitWidth {
-        animation: Appearance.animation.elementResize.numberAnimation.createObject(this)
+        NumberAnimation {
+            duration: 450
+            easing.type: Easing.OutExpo
+        }
     }
     Behavior on implicitHeight {
-        animation: Appearance.animation.elementResize.numberAnimation.createObject(this)
+        NumberAnimation {
+            duration: 450
+            easing.type: Easing.OutExpo
+        }
     }
 
     ColumnLayout {

--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -62,7 +62,7 @@ Item { // Bar content region
     // Background shadow
     Loader {
         active: root.showBarBackground && Config.options.bar.cornerStyle === 1 && Config.options.bar.floatStyleShadow
-        anchors.fill: barBackground
+        anchors.fill: backgroundGroup
         sourceComponent: StyledRectangularShadow {
             anchors.fill: undefined // The loader's anchors act on this, and this should not have any anchor
             target: barBackground
@@ -110,103 +110,113 @@ Item { // Bar content region
         }
     }
 
-    // Background
-    Rectangle {
-        id: barBackground
-        z: -10 // making sure its behind everything
-        anchors {
-            top: parent.top
-            bottom: parent.bottom
-            left: root.isDynamicIsland ? undefined : parent.left
-            right: root.isDynamicIsland ? undefined : parent.right
-            horizontalCenter: root.isDynamicIsland ? parent.horizontalCenter : undefined
-            margins: Config.options.bar.cornerStyle === 1 ? (Appearance.sizes.hyprlandGapsOut) : 0
+    Item {
+        id: backgroundGroup
+        z: -10
+        anchors.fill: parent
+
+        property color actualColor: root.showBarBackground ? (Config.options.bar.expressiveColors ? activeTheme.barBackground : Appearance.colors.colLayer0) : "transparent"
+        
+        Behavior on actualColor {
+            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(backgroundGroup)
         }
 
-        readonly property int islandSectionSpacing: 48 //spacing between the three modules
-        width: root.isDynamicIsland ? (Math.max(islandSections.implicitWidth + 12, 200)) : parent.width
+        opacity: actualColor.a
+        layer.enabled: actualColor.a > 0.0 && actualColor.a < 1.0
 
-        color: root.showBarBackground ? (Config.options.bar.expressiveColors ? activeTheme.barBackground : Appearance.colors.colLayer0) : "transparent"
-        property real baseRadius: root.isDynamicIsland ? height / 2 : (Config.options.bar.cornerStyle === 1 || Config.options.appearance.fakeScreenRounding === 4 ? Appearance.rounding.windowRounding : 0)
-        topLeftRadius: (!Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
-        topRightRadius: (!Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
-        bottomLeftRadius: (Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
-        bottomRightRadius: (Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
-        border.width: (Config.options.bar.cornerStyle === 1) ? 1 : 0
-        border.color: root.showBarBackground ? Appearance.colors.colLayer0Border : "transparent"
+        // Background
+        Rectangle {
+            id: barBackground
+            anchors {
+                top: parent.top
+                bottom: parent.bottom
+                left: root.isDynamicIsland ? undefined : parent.left
+                right: root.isDynamicIsland ? undefined : parent.right
+                horizontalCenter: root.isDynamicIsland ? parent.horizontalCenter : undefined
+                margins: Config.options.bar.cornerStyle === 1 ? (Appearance.sizes.hyprlandGapsOut) : 0
+            }
 
-        Behavior on color {
-            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
-        }
+            readonly property int islandSectionSpacing: 48 //spacing between the three modules
+            width: root.isDynamicIsland ? (Math.max(islandSections.implicitWidth + 12, 200)) : parent.width
 
-        Behavior on width {
-            enabled: !root.isDynamicIsland
-            NumberAnimation {
-                duration: 450
-                easing.type: Easing.OutExpo
+            color: Qt.rgba(backgroundGroup.actualColor.r, backgroundGroup.actualColor.g, backgroundGroup.actualColor.b, 1.0)
+            property real baseRadius: root.isDynamicIsland ? height / 2 : (Config.options.bar.cornerStyle === 1 || Config.options.appearance.fakeScreenRounding === 4 ? Appearance.rounding.windowRounding : 0)
+            topLeftRadius: (!Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
+            topRightRadius: (!Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
+            bottomLeftRadius: (Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
+            bottomRightRadius: (Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
+            border.width: (Config.options.bar.cornerStyle === 1) ? 1 : 0
+            border.color: root.showBarBackground ? Appearance.colors.colLayer0Border : "transparent"
+
+            Behavior on width {
+                enabled: !root.isDynamicIsland
+                NumberAnimation {
+                    duration: 450
+                    easing.type: Easing.OutExpo
+                }
             }
         }
-    }
 
-    // Concave Corners (HUD Mode)
-    RoundCorner {
-        z: -5
-        anchors.top: barBackground.top
-        anchors.right: barBackground.left
-        implicitSize: barBackground.baseRadius
-        color: barBackground.color
-        corner: RoundCorner.CornerEnum.TopRight
-        visible: root.isDynamicIsland && root.showBarBackground && !Config.options.bar.bottom
-        opacity: visible ? 1 : 0
-        Behavior on opacity {
-            NumberAnimation {
-                duration: 250
+        // Concave Corners (HUD Mode)
+        RoundCorner {
+            anchors.top: barBackground.top
+            anchors.right: barBackground.left
+            implicitSize: barBackground.baseRadius
+            extendHorizontal: true
+            color: barBackground.color
+            corner: RoundCorner.CornerEnum.TopRight
+            visible: root.isDynamicIsland && root.showBarBackground && !Config.options.bar.bottom
+            opacity: visible ? 1 : 0
+            Behavior on opacity {
+                NumberAnimation {
+                    duration: 250
+                }
             }
         }
-    }
-    RoundCorner {
-        z: -5
-        anchors.top: barBackground.top
-        anchors.left: barBackground.right
-        implicitSize: barBackground.baseRadius
-        color: barBackground.color
-        corner: RoundCorner.CornerEnum.TopLeft
-        visible: root.isDynamicIsland && root.showBarBackground && !Config.options.bar.bottom
-        opacity: visible ? 1 : 0
-        Behavior on opacity {
-            NumberAnimation {
-                duration: 250
+        RoundCorner {
+            anchors.top: barBackground.top
+            anchors.left: barBackground.right
+            implicitSize: barBackground.baseRadius
+            extendHorizontal: true
+            color: barBackground.color
+            corner: RoundCorner.CornerEnum.TopLeft
+            visible: root.isDynamicIsland && root.showBarBackground && !Config.options.bar.bottom
+            opacity: visible ? 1 : 0
+            Behavior on opacity {
+                NumberAnimation {
+                    duration: 250
+                }
             }
         }
-    }
 
-    RoundCorner {
-        z: -5
-        anchors.bottom: barBackground.bottom
-        anchors.right: barBackground.left
-        implicitSize: barBackground.baseRadius
-        color: barBackground.color
-        corner: RoundCorner.CornerEnum.BottomRight
-        visible: root.isDynamicIsland && root.showBarBackground && Config.options.bar.bottom
-        opacity: visible ? 1 : 0
-        Behavior on opacity {
-            NumberAnimation {
-                duration: 250
+        RoundCorner {
+            anchors.bottom: barBackground.bottom
+            anchors.right: barBackground.left
+            implicitSize: barBackground.baseRadius
+            extendHorizontal: true
+            color: barBackground.color
+            corner: RoundCorner.CornerEnum.BottomRight
+            visible: root.isDynamicIsland && root.showBarBackground && Config.options.bar.bottom
+            opacity: visible ? 1 : 0
+            Behavior on opacity {
+                NumberAnimation {
+                    duration: 250
+                }
             }
         }
-    }
-    RoundCorner {
-        z: -5
-        anchors.bottom: barBackground.bottom
-        anchors.left: barBackground.right
-        implicitSize: barBackground.baseRadius
-        color: barBackground.color
-        corner: RoundCorner.CornerEnum.BottomLeft
-        visible: root.isDynamicIsland && root.showBarBackground && Config.options.bar.bottom
-        opacity: visible ? 1 : 0
-        Behavior on opacity {
-            NumberAnimation {
-                duration: 250
+        RoundCorner {
+            anchors.bottom: barBackground.bottom
+            anchors.left: barBackground.right
+            implicitSize: barBackground.baseRadius
+            extendHorizontal: true
+            color: barBackground.color
+            corner: RoundCorner.CornerEnum.BottomLeft
+            visible: root.isDynamicIsland && root.showBarBackground && Config.options.bar.bottom
+            opacity: visible ? 1 : 0
+            Behavior on opacity {
+                NumberAnimation {
+                    duration: 250
+                }
             }
         }
     }
@@ -243,9 +253,9 @@ Item { // Bar content region
     Item {
         id: leftStopper
         anchors {
-            top: barBackground.top
-            bottom: barBackground.bottom
-            left: barBackground.left
+            top: backgroundGroup.top
+            bottom: backgroundGroup.bottom
+            left: backgroundGroup.left
             leftMargin: 4
         }
         width: 1
@@ -255,9 +265,9 @@ Item { // Bar content region
         id: islandSections
         visible: root.isDynamicIsland
         anchors {
-            top: barBackground.top
-            bottom: barBackground.bottom
-            horizontalCenter: barBackground.horizontalCenter
+            top: backgroundGroup.top
+            bottom: backgroundGroup.bottom
+            horizontalCenter: backgroundGroup.horizontalCenter
         }
         spacing: barBackground.islandSectionSpacing
 
@@ -316,8 +326,8 @@ Item { // Bar content region
         id: leftSection
         visible: !root.isDynamicIsland
         anchors {
-            top: barBackground.top
-            bottom: barBackground.bottom
+            top: backgroundGroup.top
+            bottom: backgroundGroup.bottom
             left: leftStopper.right
         }
         spacing: 4
@@ -336,9 +346,9 @@ Item { // Bar content region
         id: middleSection
         visible: !root.isDynamicIsland
         anchors {
-            top: barBackground.top
-            bottom: barBackground.bottom
-            horizontalCenter: barBackground.horizontalCenter
+            top: backgroundGroup.top
+            bottom: backgroundGroup.bottom
+            horizontalCenter: backgroundGroup.horizontalCenter
         }
         width: Math.max(middleLeft.width, middleRight.width) * 2 + centerCenter.width + 8
 
@@ -398,8 +408,8 @@ Item { // Bar content region
         id: rightSection
         visible: !root.isDynamicIsland
         anchors {
-            top: barBackground.top
-            bottom: barBackground.bottom
+            top: backgroundGroup.top
+            bottom: backgroundGroup.bottom
             right: rightStopper.left
             rightMargin: 4
         }
@@ -418,9 +428,9 @@ Item { // Bar content region
     Item {
         id: rightStopper
         anchors {
-            top: barBackground.top
-            bottom: barBackground.bottom
-            right: barBackground.right
+            top: backgroundGroup.top
+            bottom: backgroundGroup.bottom
+            right: backgroundGroup.right
         }
         width: 1
     }

--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -140,6 +140,7 @@ Item { // Bar content region
         }
 
         Behavior on width {
+            enabled: !root.isDynamicIsland
             NumberAnimation {
                 duration: 450
                 easing.type: Easing.OutExpo

--- a/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveActiveWindow.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveActiveWindow.qml
@@ -30,8 +30,8 @@ Item {
     property string appTitleText: root.focusingThisMonitor && root.activeWindow?.activated && root.biggestWindow ? 
                 root.activeWindow?.title : (root.biggestWindow?.title) ?? `${Translation.tr("Workspace")} ${monitor?.activeWorkspace?.id ?? 1}`
     
-    implicitHeight: root.vertical && isFixedSize ? fixedSize : (root.vertical ? Math.max(classText.implicitWidth, titleText.implicitWidth) + 20 : colLayout.implicitHeight)
-    implicitWidth: !root.vertical && isFixedSize ? fixedSize : (root.vertical ? undefined : Math.min(Math.max(classText.implicitWidth, titleText.implicitWidth) + 20, maxSize))
+    implicitHeight: root.vertical && isFixedSize ? fixedSize : (root.vertical ? Math.max(expressiveText.implicitWidth) + 30 : Appearance.sizes.baseBarHeight)
+    implicitWidth: !root.vertical && isFixedSize ? fixedSize : (root.vertical ? Appearance.sizes.verticalBarWidth : Math.min(Math.max(expressiveText.implicitWidth) + 30, maxSize))
     clip: true
 
     property bool containsMouse: mouseArea.containsMouse
@@ -67,37 +67,28 @@ Item {
         }
     }
 
-    ColumnLayout {
-        visible: true
-        id: colLayout
-
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        spacing: -4
-
-        width: root.vertical ? implicitWidth : root.width
-        height: root.vertical ? root.height : implicitHeight
+    Rectangle {
+        anchors.fill: parent
+        anchors.margins: 4
+        radius: Appearance.rounding.full
+        color: "transparent"
+        border.color: Appearance.colors.colTertiaryContainer
+        border.width: 2
 
         StyledText {
-            id: classText
-            Layout.leftMargin: 6
-            visible: !root.vertical
-            Layout.fillWidth: true
-            font.pixelSize: Appearance.font.pixelSize.smaller
-            color: Appearance.colors.colSubtext
-            elide: Text.ElideRight
-            text: root.appClassText
-        }
-
-        StyledText {
-            id: titleText
-            Layout.leftMargin: root.vertical ? 0 : 6
-            Layout.fillWidth: true
+            id: expressiveText
+            anchors.centerIn: parent
+            rotation: root.vertical ? -90 : 0
+            text: root.vertical ? root.appClassText : root.appTitleText
+            font.family: Appearance.font.family.expressive
+            font.variableAxes: Appearance.font.variableAxes.rounded
+            font.weight: Font.Bold
             font.pixelSize: Appearance.font.pixelSize.small
             color: Appearance.colors.colOnLayer0
             elide: Text.ElideRight
-            rotation: root.vertical ? -90 : 0
-            text: root.vertical ? root.appClassText : root.appTitleText
+            width: root.vertical ? parent.height - 20 : parent.width - 20
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
         }
     }
 }

--- a/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalBarContent.qml
@@ -86,64 +86,74 @@ Item { // Bar content region
         }
     }
 
-    // Background
-    Rectangle {
-        id: barBackground
-        z: -10 // making sure its behind everything
-        anchors {
-            fill: root.isDynamicIsland ? undefined : parent
-            centerIn: root.isDynamicIsland ? parent : undefined
+    Item {
+        id: backgroundGroup
+        z: -10
+        anchors.fill: parent
+
+        property color actualColor: root.showBarBackground ? (Config.options.bar.expressiveColors ? activeTheme.barBackground : Appearance.colors.colLayer0) : "transparent"
+        Behavior on actualColor {
+            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(backgroundGroup)
         }
 
-        width: parent.width
-        height: root.isDynamicIsland ? (Math.max(islandSections.implicitHeight + 24, 200)) : parent.height
+        opacity: actualColor.a
+        layer.enabled: actualColor.a > 0.0 && actualColor.a < 1.0
 
-        color: root.showBarBackground ? (Config.options.bar.expressiveColors ? activeTheme.barBackground : Appearance.colors.colLayer0) : "transparent"
-        property real baseRadius: root.isDynamicIsland ? width / 2 : (Config.options.bar.cornerStyle === 1 || Config.options.appearance.fakeScreenRounding === 4 ? Appearance.rounding.windowRounding : 0)
+        // Background
+        Rectangle {
+            id: barBackground
+            anchors {
+                fill: root.isDynamicIsland ? undefined : parent
+                centerIn: root.isDynamicIsland ? parent : undefined
+            }
 
-        // In vertical mode (Left/Right), the edges touching the screen are left/right.
-        // For Left bar (bottom: false): left edges are 0.
-        // For Right bar (bottom: true): right edges are 0.
-        topLeftRadius: (!Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
-        bottomLeftRadius: (!Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
-        topRightRadius: (Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
-        bottomRightRadius: (Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
+            width: parent.width
+            height: root.isDynamicIsland ? (Math.max(islandSections.implicitHeight + 24, 200)) : parent.height
 
-        border.width: (Config.options.bar.cornerStyle === 1) ? 1 : 0
-        border.color: root.showBarBackground ? Appearance.colors.colLayer0Border : "transparent"
+            color: Qt.rgba(backgroundGroup.actualColor.r, backgroundGroup.actualColor.g, backgroundGroup.actualColor.b, 1.0)
+            property real baseRadius: root.isDynamicIsland ? width / 2 : (Config.options.bar.cornerStyle === 1 || Config.options.appearance.fakeScreenRounding === 4 ? Appearance.rounding.windowRounding : 0)
 
-        Behavior on color {
-            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
-        }
-        Behavior on height {
-            enabled: !root.isDynamicIsland
-            NumberAnimation {
-                duration: 450
-                easing.type: Easing.OutExpo
+            // In vertical mode (Left/Right), the edges touching the screen are left/right.
+            // For Left bar (bottom: false): left edges are 0.
+            // For Right bar (bottom: true): right edges are 0.
+            topLeftRadius: (!Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
+            bottomLeftRadius: (!Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
+            topRightRadius: (Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
+            bottomRightRadius: (Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
+
+            border.width: (Config.options.bar.cornerStyle === 1) ? 1 : 0
+            border.color: root.showBarBackground ? Appearance.colors.colLayer0Border : "transparent"
+
+            Behavior on height {
+                enabled: !root.isDynamicIsland
+                NumberAnimation {
+                    duration: 450
+                    easing.type: Easing.OutExpo
+                }
             }
         }
-    }
 
-    // Concave Corners (HUD Mode)
-    RoundCorner {
-        z: -5
-        anchors.bottom: barBackground.top
-        anchors.left: Config.options.bar.bottom ? undefined : barBackground.left
-        anchors.right: Config.options.bar.bottom ? barBackground.right : undefined
-        implicitSize: barBackground.baseRadius
-        color: barBackground.color
-        corner: Config.options.bar.bottom ? RoundCorner.CornerEnum.BottomRight : RoundCorner.CornerEnum.BottomLeft
-        visible: root.isDynamicIsland && root.showBarBackground
-    }
-    RoundCorner {
-        z: -5
-        anchors.top: barBackground.bottom
-        anchors.left: Config.options.bar.bottom ? undefined : barBackground.left
-        anchors.right: Config.options.bar.bottom ? barBackground.right : undefined
-        implicitSize: barBackground.baseRadius
-        color: barBackground.color
-        corner: Config.options.bar.bottom ? RoundCorner.CornerEnum.TopRight : RoundCorner.CornerEnum.TopLeft
-        visible: root.isDynamicIsland && root.showBarBackground
+        // Concave Corners (HUD Mode)
+        RoundCorner {
+            anchors.bottom: barBackground.top
+            anchors.left: Config.options.bar.bottom ? undefined : barBackground.left
+            anchors.right: Config.options.bar.bottom ? barBackground.right : undefined
+            implicitSize: barBackground.baseRadius
+            extendVertical: true
+            color: barBackground.color
+            corner: Config.options.bar.bottom ? RoundCorner.CornerEnum.BottomRight : RoundCorner.CornerEnum.BottomLeft
+            visible: root.isDynamicIsland && root.showBarBackground
+        }
+        RoundCorner {
+            anchors.top: barBackground.bottom
+            anchors.left: Config.options.bar.bottom ? undefined : barBackground.left
+            anchors.right: Config.options.bar.bottom ? barBackground.right : undefined
+            implicitSize: barBackground.baseRadius
+            extendVertical: true
+            color: barBackground.color
+            corner: Config.options.bar.bottom ? RoundCorner.CornerEnum.TopRight : RoundCorner.CornerEnum.TopLeft
+            visible: root.isDynamicIsland && root.showBarBackground
+        }
     }
 
     ColumnLayout { // Combined Island section

--- a/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalBarContent.qml
@@ -116,6 +116,7 @@ Item { // Bar content region
             animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
         }
         Behavior on height {
+            enabled: !root.isDynamicIsland
             NumberAnimation {
                 duration: 450
                 easing.type: Easing.OutExpo


### PR DESCRIPTION
## Describe your changes

Made the "active window" widget on the bar follow the same animation speed as the dynamic island so everything says contained inside the dynamic island even on big bar size change.

## Is it ready? Questions/feedback needed?

It's ready since the vertical bar doesn't allow for big bar size change anyway