### PR TITLE
fix(bar): round float bar shadow and adjust offset dynamically

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/StyledRectangularShadow.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/StyledRectangularShadow.qml
@@ -7,7 +7,8 @@ RectangularShadow {
     anchors.fill: target
     radius: target.radius
     blur: 0.9 * Appearance.sizes.elevationMargin
-    offset: Qt.vector2d(0.0, 1.0)
+    property vector2d shadowOffset: Qt.vector2d(0.0, 1.0)
+    offset: shadowOffset
     spread: 1
     color: Appearance.colors.colShadow
     cached: true

--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -68,6 +68,7 @@ Item { // Bar content region
         sourceComponent: StyledRectangularShadow {
             anchors.fill: undefined // The loader's anchors act on this, and this should not have any anchor
             target: barBackground
+            shadowOffset: Qt.vector2d(0.0, Config.options.bar.bottom ? 1.0 : -1.0)
         }
     }
     BarThemes {
@@ -143,6 +144,7 @@ Item { // Bar content region
 
             color: Qt.rgba(backgroundGroup.actualColor.r, backgroundGroup.actualColor.g, backgroundGroup.actualColor.b, 1.0)
             property real baseRadius: root.isDynamicIsland ? height / 2 : (Config.options.bar.cornerStyle === 1 || Config.options.appearance.fakeScreenRounding === 4 ? Appearance.rounding.windowRounding : 0)
+            radius: baseRadius
             topLeftRadius: (!Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
             topRightRadius: (!Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius
             bottomLeftRadius: (Config.options.bar.bottom && (root.isDynamicIsland || Config.options.appearance.fakeScreenRounding === 4)) ? 0 : baseRadius

--- a/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalBarContent.qml
@@ -56,6 +56,7 @@ Item { // Bar content region
         sourceComponent: StyledRectangularShadow {
             anchors.fill: undefined // The loader's anchors act on this, and this should not have any anchor
             target: barBackground
+            shadowOffset: Qt.vector2d(Config.options.bar.bottom ? 1.0 : -1.0, 0.0)
         }
     }
     Bar.BarThemes {
@@ -113,6 +114,7 @@ Item { // Bar content region
 
             color: Qt.rgba(backgroundGroup.actualColor.r, backgroundGroup.actualColor.g, backgroundGroup.actualColor.b, 1.0)
             property real baseRadius: root.isDynamicIsland ? width / 2 : (Config.options.bar.cornerStyle === 1 || Config.options.appearance.fakeScreenRounding === 4 ? Appearance.rounding.windowRounding : 0)
+            radius: baseRadius
 
             // In vertical mode (Left/Right), the edges touching the screen are left/right.
             // For Left bar (bottom: false): left edges are 0.


### PR DESCRIPTION
## Describe your changes

Enabled corner rounding for the quickshell Float bar's shadow so that it matches the rounded bar background.
Dynamically adjusted the shadow's direction so that it is always cast into the gap between the bar and the nearest screen edge.

## Is it ready? Questions/feedback needed?

It's ready

Edit : it's not, someone reported that the windows moves down when screenshot and the shadows becomes bigger. I'll take a look at this