### PR TITLE
feat(icon tint): add slider to controll tint percentage

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -254,6 +254,7 @@ Singleton {
                 property string globalRounding: "large" // Options: "sharp", "normal", "large", "verylarge"
                 property int defaultBorderRadius: 18
                 property bool toggleWindowRounding: true // Changes Hyprland window rounding to 0 if sharpMode is true
+                property real iconTintPercentage: 0.6
                 property JsonObject fonts: JsonObject {
                     property bool enableCustom: false
                     property string main: "Google Sans Flex"

--- a/dots/.config/quickshell/ii/modules/ii/bar/Workspaces.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/Workspaces.qml
@@ -735,7 +735,7 @@ Item {
                                         ColorOverlay {
                                             anchors.fill: desaturatedIcon
                                             source: desaturatedIcon
-                                            color: ColorUtils.transparentize(Appearance.colors.colPrimary, 0.6)
+                                            color: ColorUtils.transparentize(Appearance.colors.colPrimary, Config.options.appearance.iconTintPercentage)
                                         }
                                     }
                                 }

--- a/dots/.config/quickshell/ii/modules/ii/dock/widgets/DockIcon.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/widgets/DockIcon.qml
@@ -103,7 +103,7 @@ Item {
             ColorOverlay {
                 anchors.fill: parent
                 source: monoDesat
-                color: ColorUtils.transparentize(Appearance.colors.colPrimary, 0.6)
+                color: ColorUtils.transparentize(Appearance.colors.colPrimary, Config.options.appearance.iconTintPercentage)
             }
         }
     }

--- a/dots/.config/quickshell/ii/modules/settings/configs/InterfaceFontsConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/InterfaceFontsConfig.qml
@@ -190,6 +190,15 @@ ContentPage {
                 text: Translation.tr("Applies monochrome tint to workspaces icons. Turn on show workspace icons to see this")
             }
         }
+
+        ConfigSlider {
+            buttonIcon: "humidity_percentage"
+            text: Translation.tr("Tint percentage")
+            value: Config.options.appearance.iconTintPercentage ?? 0.6
+            onValueChanged: Config.options.appearance.iconTintPercentage = value;
+            enabled: Config.options.bar.workspaces.monochromeIcons
+            opacity: enabled ? 1.0 : 0.5
+        }
     }
 
     ContentSection {


### PR DESCRIPTION
## Describe your changes

Just added slider into "Interface & Fonts" under the "Base Icon Themes". Added property into appearance of Config.qml named `iconTintPercentage`. And also put that property into DockIcon and Workscpaces qmls instead of hardcoded 0.6

## Is it ready? Questions/feedback needed?

Yeap, it works both for workspaces and dock. Very little enhancement but 0.6 is too much for me haha