### PR TITLE
Fix active window tooltip click to show

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/ActiveWindow.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ActiveWindow.qml
@@ -30,8 +30,8 @@ Item {
     property string appTitleText: root.focusingThisMonitor && root.activeWindow?.activated && root.biggestWindow ? 
                 root.activeWindow?.title : (root.biggestWindow?.title) ?? `${Translation.tr("Workspace")} ${monitor?.activeWorkspace?.id ?? 1}`
     
-    implicitHeight: root.vertical && isFixedSize ? fixedSize : (root.vertical ? Math.max(classText.implicitWidth, titleText.implicitWidth) + 20 : colLayout.implicitHeight)
-    implicitWidth: !root.vertical && isFixedSize ? fixedSize : (root.vertical ? undefined : Math.min(Math.max(classText.implicitWidth, titleText.implicitWidth) + 20, maxSize))
+    implicitHeight: root.vertical && isFixedSize ? fixedSize : (root.vertical ? Math.max(classText.implicitWidth, titleText.implicitWidth) + 20 : Appearance.sizes.baseBarHeight)
+    implicitWidth: !root.vertical && isFixedSize ? fixedSize : (root.vertical ? Appearance.sizes.verticalBarWidth : Math.min(Math.max(classText.implicitWidth, titleText.implicitWidth) + 20, maxSize))
     clip: true
 
     property bool containsMouse: mouseArea.containsMouse

--- a/dots/.config/quickshell/ii/modules/ii/bar/ActiveWindow.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ActiveWindow.qml
@@ -39,8 +39,7 @@ Item {
     MouseArea {
         id: mouseArea
         anchors.fill: parent
-        hoverEnabled: true
-        acceptedButtons: Qt.NoButton
+        hoverEnabled: !Config.options.bar.tooltips.clickToShow
     }
 
     ActiveWindowPopup {

--- a/dots/.config/quickshell/ii/modules/ii/bar/ActiveWindowPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ActiveWindowPopup.qml
@@ -17,7 +17,6 @@ StyledPopup {
 
     hoverTarget: targetItem
     stickyHover: true
-    active: (stickyHover ? _stickyActive : (hoverTarget && hoverTarget.containsMouse)) && appTitleText !== ""
 
     Rectangle {
         implicitWidth: Math.max(popupRoot.popupWidth, Math.min(popupRoot.maxPopupWidth, popupText.implicitWidth + 32))

--- a/dots/.config/quickshell/ii/modules/ii/bar/DashboardPanelButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/DashboardPanelButton.qml
@@ -21,7 +21,7 @@ RippleButton { // Right sidebar button
     bottomRightRadius: endRadius
 
     implicitWidth: indicatorsRowLayout.implicitWidth + 12 * 2
-    implicitHeight: indicatorsRowLayout.implicitHeight + 4 * 2
+    implicitHeight: Appearance.sizes.baseBarHeight
 
     colBackgroundHover: Appearance.colors.colLayer1Hover
     colRipple: Appearance.colors.colLayer1Active

--- a/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveActiveWindow.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveActiveWindow.qml
@@ -39,8 +39,7 @@ Item {
     MouseArea {
         id: mouseArea
         anchors.fill: parent
-        hoverEnabled: true
-        acceptedButtons: Qt.NoButton
+        hoverEnabled: !Config.options.bar.tooltips.clickToShow
     }
 
     ActiveWindowPopup {

--- a/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveResources.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveResources.qml
@@ -294,7 +294,6 @@ Item {
 
         anchors.fill: parent
         hoverEnabled: !Config.options.bar.tooltips.clickToShow
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
     }
 
     Behavior on implicitHeight {

--- a/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveResources.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ExpressiveResources.qml
@@ -1,12 +1,12 @@
-import qs.services
-import qs.modules.common
-import qs.modules.common.widgets
-import QtQuick
-import QtQuick.Layouts
-
 // ─────────────────────────────────────────────────────────────────────────────
 // ExpressiveResources — redesign total M3 Expressive
-//
+
+import QtQuick
+import QtQuick.Layouts
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+
 // Bar widget: cada recurso ativo = MaterialShape colorido (cookie shape)
 // com ícone preenchido + texto percentual flutuante. As cores de shape
 // indicam nível de uso via opacidade/saturação — primário para CPU/RAM,
@@ -14,35 +14,31 @@ import QtQuick.Layouts
 // ─────────────────────────────────────────────────────────────────────────────
 Item {
     id: root
+
     property bool vertical: false
     property bool alwaysShowAllResources: false
     property bool isMaterial: true // Forced expressive
-
-    implicitWidth:  vertical ? mainCol.implicitWidth  : mainRow.implicitWidth
-    implicitHeight: vertical ? mainCol.implicitHeight : mainRow.implicitHeight
-    width: implicitWidth
-    height: implicitHeight
-
     // ── Helpers ───────────────────────────────────────────────────────────────
     readonly property int _shapeSize: Appearance.sizes.baseBarHeight - 10
     readonly property int _shapeVSize: Appearance.sizes.verticalBarWidth - 10
 
     // Color for a resource shape based on usage level
     function shapeColor(pct, baseColor, warnColor) {
-        if (pct >= 0.85) return warnColor ?? Appearance.colors.colError
-        return baseColor
+        if (pct >= 0.85)
+            return warnColor ?? Appearance.colors.colError;
+
+        return baseColor;
     }
 
-    Behavior on implicitHeight {
-        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(root)
-    }
-    Behavior on implicitWidth {
-        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(root)
-    }
+    implicitWidth: vertical ? Appearance.sizes.verticalBarWidth : mainRow.implicitWidth
+    implicitHeight: vertical ? mainCol.implicitHeight : Appearance.sizes.baseBarHeight
+    width: implicitWidth
+    height: implicitHeight
 
     // ── Horizontal Layout ─────────────────────────────────────────────────────
     RowLayout {
         id: mainRow
+
         visible: !root.vertical
         spacing: 4
         anchors.centerIn: parent
@@ -50,13 +46,16 @@ Item {
         // ── Resource shapes row ───────────────────────────────────────────────
         RowLayout {
             id: resourcesRow
+
             spacing: 3
 
             // CPU — Cookie12Sided, primary color family
             Loader {
                 id: cpuShapeH
+
                 active: Config.options.bar.resources.alwaysShowCpu
                 visible: active
+
                 sourceComponent: ResourceShape {
                     iconName: "memory_alt"
                     percentage: ResourceUsage.cpuUsage
@@ -66,13 +65,16 @@ Item {
                     size: root._shapeSize
                     warningThreshold: Config.options.bar.resources.cpuWarningThreshold
                 }
+
             }
 
             // RAM — Clover shape, secondary color
             Loader {
                 id: ramShapeH
+
                 active: Config.options.bar.resources.alwaysShowRam
                 visible: active
+
                 sourceComponent: ResourceShape {
                     iconName: "memory"
                     percentage: ResourceUsage.memoryUsedPercentage
@@ -82,13 +84,16 @@ Item {
                     size: root._shapeSize
                     warningThreshold: Config.options.bar.resources.memoryWarningThreshold
                 }
+
             }
 
             // CPU Temp — sunny shape, tertiary
             Loader {
                 id: tempShapeH
+
                 active: Config.options.bar.resources.alwaysShowCpuTemp
                 visible: active
+
                 sourceComponent: ResourceShape {
                     iconName: "thermostat"
                     percentage: ResourceUsage.cpuTemp / 100
@@ -98,13 +103,16 @@ Item {
                     size: root._shapeSize
                     warningThreshold: 80
                 }
+
             }
 
             // Disk — Cookie7Sided, secondary container tinted
             Loader {
                 id: diskShapeH
+
                 active: Config.options.bar.resources.alwaysShowDisk
                 visible: active
+
                 sourceComponent: ResourceShape {
                     iconName: "hard_drive"
                     percentage: ResourceUsage.diskUsedPercentage
@@ -114,13 +122,16 @@ Item {
                     size: root._shapeSize
                     warningThreshold: 90
                 }
+
             }
 
             // Swap — Cookie9Sided, tertiary container
             Loader {
                 id: swapShapeH
+
                 active: Config.options.bar.resources.alwaysShowSwap
                 visible: active
+
                 sourceComponent: ResourceShape {
                     iconName: "swap_horiz"
                     percentage: ResourceUsage.swapUsedPercentage
@@ -130,21 +141,31 @@ Item {
                     size: root._shapeSize
                     warningThreshold: Config.options.bar.resources.swapWarningThreshold
                 }
+
             }
+
         }
 
         // ── Docker capsule (horizontal) ───────────────────────────────────────
         Loader {
             id: dockerHLoader
+
             active: Config.options.bar.resources.showDocker && DockerService.dockerRunning
             visible: active
-            sourceComponent: DockerCapsule { vertical: false; barHeight: root._shapeSize }
+
+            sourceComponent: DockerCapsule {
+                vertical: false
+                barHeight: root._shapeSize
+            }
+
         }
+
     }
 
     // ── Vertical Layout ───────────────────────────────────────────────────────
     ColumnLayout {
         id: mainCol
+
         visible: root.vertical
         spacing: 4
         anchors.centerIn: parent
@@ -157,6 +178,7 @@ Item {
                 active: Config.options.bar.resources.alwaysShowCpu
                 visible: active
                 Layout.alignment: Qt.AlignHCenter
+
                 sourceComponent: ResourceShape {
                     iconName: "memory_alt"
                     percentage: ResourceUsage.cpuUsage
@@ -166,12 +188,14 @@ Item {
                     size: root._shapeVSize
                     warningThreshold: Config.options.bar.resources.cpuWarningThreshold
                 }
+
             }
 
             Loader {
                 active: Config.options.bar.resources.alwaysShowRam
                 visible: active
                 Layout.alignment: Qt.AlignHCenter
+
                 sourceComponent: ResourceShape {
                     iconName: "memory"
                     percentage: ResourceUsage.memoryUsedPercentage
@@ -181,12 +205,14 @@ Item {
                     size: root._shapeVSize
                     warningThreshold: Config.options.bar.resources.memoryWarningThreshold
                 }
+
             }
 
             Loader {
                 active: Config.options.bar.resources.alwaysShowCpuTemp
                 visible: active
                 Layout.alignment: Qt.AlignHCenter
+
                 sourceComponent: ResourceShape {
                     iconName: "thermostat"
                     percentage: ResourceUsage.cpuTemp / 100
@@ -196,12 +222,14 @@ Item {
                     size: root._shapeVSize
                     warningThreshold: 80
                 }
+
             }
 
             Loader {
                 active: Config.options.bar.resources.alwaysShowDisk
                 visible: active
                 Layout.alignment: Qt.AlignHCenter
+
                 sourceComponent: ResourceShape {
                     iconName: "hard_drive"
                     percentage: ResourceUsage.diskUsedPercentage
@@ -211,12 +239,14 @@ Item {
                     size: root._shapeVSize
                     warningThreshold: 90
                 }
+
             }
 
             Loader {
                 active: Config.options.bar.resources.alwaysShowSwap
                 visible: active
                 Layout.alignment: Qt.AlignHCenter
+
                 sourceComponent: ResourceShape {
                     iconName: "swap_horiz"
                     percentage: ResourceUsage.swapUsedPercentage
@@ -226,7 +256,9 @@ Item {
                     size: root._shapeVSize
                     warningThreshold: Config.options.bar.resources.swapWarningThreshold
                 }
+
             }
+
         }
 
         // ── Docker capsule (vertical) ─────────────────────────────────────────
@@ -234,8 +266,14 @@ Item {
             active: Config.options.bar.resources.showDocker && DockerService.dockerRunning
             visible: active
             Layout.alignment: Qt.AlignHCenter
-            sourceComponent: DockerCapsule { vertical: true; barHeight: root._shapeVSize }
+
+            sourceComponent: DockerCapsule {
+                vertical: true
+                barHeight: root._shapeVSize
+            }
+
         }
+
     }
 
     // ── Popup declaration ────────────────────────────────────────────────────
@@ -243,17 +281,35 @@ Item {
         hoverTarget: hoverArea
         Component.onCompleted: {
             activeChanged.connect(() => {
-                if (active) {
+                if (active)
                     DockerService.refreshForPopup();
-                }
+
             });
         }
+    }
+
+    // Internal MouseArea for hover popups and custom click behaviors
+    MouseArea {
+        id: hoverArea
+
+        anchors.fill: parent
+        hoverEnabled: !Config.options.bar.tooltips.clickToShow
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+    }
+
+    Behavior on implicitHeight {
+        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(root)
+    }
+
+    Behavior on implicitWidth {
+        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(root)
     }
 
     // ══ ResourceShape inline component ════════════════════════════════════════
     // A MaterialShape cookie with icon + optional percentage arc overlay
     component ResourceShape: Item {
         id: rs
+
         required property string iconName
         required property double percentage
         required property color baseColor
@@ -261,29 +317,17 @@ Item {
         required property string shapeStr
         required property int size
         property int warningThreshold: 100
-
         readonly property bool isWarning: percentage * 100 >= warningThreshold
         // Writable intermediates so animations can target them
-        property color currentColor:   isWarning ? Appearance.colors.colError   : baseColor
+        property color currentColor: isWarning ? Appearance.colors.colError : baseColor
         property color currentOnColor: isWarning ? Appearance.colors.colOnError : onBaseColor
 
         implicitWidth: size
         implicitHeight: size
 
-        // Smooth color transition on warning toggle
-        Behavior on currentColor {
-            ColorAnimation {
-                duration: Appearance.animation.elementMoveFast.duration
-            }
-        }
-        Behavior on currentOnColor {
-            ColorAnimation {
-                duration: Appearance.animation.elementMoveFast.duration
-            }
-        }
-
         MaterialShape {
             id: shape
+
             anchors.fill: parent
             shapeString: rs.shapeStr
             color: rs.currentColor
@@ -308,6 +352,7 @@ Item {
                 color: rs.currentOnColor
                 font.weight: Font.DemiBold
             }
+
         }
 
         // Percentage label — small pill below the shape
@@ -325,14 +370,14 @@ Item {
 
             StyledText {
                 id: pctLabel
+
                 anchors.centerIn: parent
                 text: {
                     if (rs.iconName === "thermostat") {
-                        if (Config.options.bar.weather.useUSCS) {
+                        if (Config.options.bar.weather.useUSCS)
                             return Math.round((rs.percentage * 100) * 1.8 + 32) + "°F";
-                        } else {
+                        else
                             return Math.round(rs.percentage * 100) + "°C";
-                        }
                     } else {
                         return Math.round(rs.percentage * 100) + "%";
                     }
@@ -341,54 +386,63 @@ Item {
                 font.weight: Font.Black
                 color: rs.currentOnColor
             }
+
         }
 
         // Warning pulse: scale up/down while isWarning
         PropertyAnimation {
             id: warnPulse
+
             target: rs
             property: "scale"
-            from: 1.0
+            from: 1
             to: 1.08
             duration: 700
             easing.type: Easing.InOutSine
             running: false
         }
+
         // Toggle pulse loop manually — avoid SequentialAnimation on readonly deps
         Timer {
             interval: 700
             repeat: true
             running: rs.isWarning
             onTriggered: {
-                rs.scale = (rs.scale > 1.04) ? 1.0 : 1.08
+                rs.scale = (rs.scale > 1.04) ? 1 : 1.08;
             }
             onRunningChanged: {
-                if (!running) rs.scale = 1.0
+                if (!running)
+                    rs.scale = 1;
+
             }
         }
+
+        // Smooth color transition on warning toggle
+        Behavior on currentColor {
+            ColorAnimation {
+                duration: Appearance.animation.elementMoveFast.duration
+            }
+
+        }
+
+        Behavior on currentOnColor {
+            ColorAnimation {
+                duration: Appearance.animation.elementMoveFast.duration
+            }
+
+        }
+
     }
 
     // ══ DockerCapsule inline component ════════════════════════════════════════
     component DockerCapsule: Item {
         id: dc
+
         property bool vertical: false
         property int barHeight: 28
 
-        implicitWidth:  vertical ? (Appearance.sizes.verticalBarWidth - 8) : (countTextH.implicitWidth + iconCircleH.width + 20)
+        implicitWidth: vertical ? (Appearance.sizes.verticalBarWidth - 8) : (countTextH.implicitWidth + iconCircleH.width + 20)
         implicitHeight: vertical ? (countTextV.implicitHeight + iconCircleV.height + 16) : (Appearance.sizes.baseBarHeight - 8)
-
-        Behavior on implicitWidth {
-            NumberAnimation {
-                duration: Appearance.animation.elementMove.duration
-                easing.type: Appearance.animation.elementMove.type
-            }
-        }
-        Behavior on implicitHeight {
-            NumberAnimation {
-                duration: Appearance.animation.elementMove.duration
-                easing.type: Appearance.animation.elementMove.type
-            }
-        }
 
         // Horizontal capsule
         Rectangle {
@@ -399,6 +453,7 @@ Item {
 
             Rectangle {
                 id: iconCircleH
+
                 anchors.left: parent.left
                 anchors.leftMargin: 4
                 anchors.verticalCenter: parent.verticalCenter
@@ -415,10 +470,12 @@ Item {
                     colorize: true
                     color: Appearance.colors.colOnPrimary
                 }
+
             }
 
             StyledText {
                 id: countTextH
+
                 anchors.right: parent.right
                 anchors.rightMargin: 10
                 anchors.verticalCenter: parent.verticalCenter
@@ -427,6 +484,7 @@ Item {
                 font.weight: Font.Black
                 color: Appearance.colors.colOnSurface
             }
+
         }
 
         // Vertical capsule
@@ -438,6 +496,7 @@ Item {
 
             Rectangle {
                 id: iconCircleV
+
                 anchors.top: parent.top
                 anchors.topMargin: 4
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -454,10 +513,12 @@ Item {
                     colorize: true
                     color: Appearance.colors.colOnPrimary
                 }
+
             }
 
             StyledText {
                 id: countTextV
+
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: 8
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -466,14 +527,25 @@ Item {
                 font.weight: Font.Black
                 color: Appearance.colors.colOnSurface
             }
+
         }
+
+        Behavior on implicitWidth {
+            NumberAnimation {
+                duration: Appearance.animation.elementMove.duration
+                easing.type: Appearance.animation.elementMove.type
+            }
+
+        }
+
+        Behavior on implicitHeight {
+            NumberAnimation {
+                duration: Appearance.animation.elementMove.duration
+                easing.type: Appearance.animation.elementMove.type
+            }
+
+        }
+
     }
 
-    // Internal MouseArea for hover popups and custom click behaviors
-    MouseArea {
-        id: hoverArea
-        anchors.fill: parent
-        hoverEnabled: !Config.options.bar.tooltips.clickToShow
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
-    }
 }

--- a/dots/.config/quickshell/ii/modules/ii/bar/ScreenShareIndicator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ScreenShareIndicator.qml
@@ -1,67 +1,72 @@
+import "./cards"
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Shapes
+import Quickshell.Io
 import qs.modules.common
 import qs.modules.common.widgets
 import qs.services
-import QtQuick
-import QtQuick.Shapes
-import QtQuick.Layouts
-import Quickshell.Io
-import "./cards"
 
 MouseArea {
     id: indicator
+
     property bool vertical: false
-
-    implicitWidth: 40
-    implicitHeight: Appearance.sizes.baseBarHeight
-
     property bool activelyScreenSharing: false
-    
+
+    implicitWidth: vertical ? Appearance.sizes.verticalBarWidth : 40
+    implicitHeight: vertical ? 40 : Appearance.sizes.baseBarHeight
     hoverEnabled: true
     Component.onCompleted: rootItem.toggleHighlight(true)
 
     Process {
         id: screenShareProc
+
         running: true
         command: ["bash", "-c", Directories.screenshareStateScript]
     }
-    
+
     FileView {
         id: stateFile
+
         path: Directories.screenshareStatePath
         watchChanges: true
         onFileChanged: this.reload()
         onLoaded: {
-            indicator.activelyScreenSharing = !stateFile.text().trim().toLowerCase().includes("none")
-            rootItem.toggleVisible(indicator.activelyScreenSharing)
+            indicator.activelyScreenSharing = !stateFile.text().trim().toLowerCase().includes("none");
+            rootItem.toggleVisible(indicator.activelyScreenSharing);
         }
     }
 
     MaterialSymbol {
         id: iconIndicator
+
         z: 1
         text: "cast"
+        color: Appearance.colors.colOnPrimary
+        font.pixelSize: Appearance.font.pixelSize.huge
+
         anchors {
             top: parent.top
             bottom: parent.bottom
             horizontalCenter: parent.horizontalCenter
         }
-        color: Appearance.colors.colOnPrimary
-        font.pixelSize: Appearance.font.pixelSize.huge
+
     }
 
     StyledPopup {
         hoverTarget: indicator
         animate: false
+
         contentItem: HeroCard {
             compactMode: true
             anchors.centerIn: parent
             icon: "cast_connected"
-
             title: stateFile.text().trim()
             subtitle: Translation.tr("is using your screen")
-
             pillText: Translation.tr("Sharing..")
             pillIcon: "screen_share"
         }
+
     }
+
 }

--- a/dots/.config/quickshell/ii/modules/ii/bar/StyledPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/StyledPopup.qml
@@ -5,6 +5,7 @@ import QtQuick
 import QtQuick.Effects
 import Quickshell
 import Quickshell.Wayland
+import Quickshell.Hyprland
 
 LazyLoader {
     id: root
@@ -36,8 +37,11 @@ LazyLoader {
     property bool _popupHovered: false
     property bool _stickyActive: false
     property bool _targetHovered: hoverTarget ? hoverTarget.containsMouse : false
+    property bool _clickActive: false
 
-    active: stickyHover ? _stickyActive : (hoverTarget && hoverTarget.containsMouse)
+    readonly property bool _computedActive: Config.options.bar.tooltips.clickToShow ? _clickActive : (stickyHover ? _stickyActive : (hoverTarget && hoverTarget.containsMouse))
+
+    active: _computedActive
 
     // I have NO FUCKING IDEA why we cant use a normal timer here
     // Because if we do, we FUCKING cannot reference the timer from anywhere
@@ -63,7 +67,17 @@ LazyLoader {
         }
     }
 
-    on_TargetHoveredChanged: _evaluateStickyState()
+    on_TargetHoveredChanged: {
+        if (Config.options.bar.tooltips.clickToShow) {
+            // Guard against the same dismiss click reopening the popup:
+            // only a press while it's currently closed opens it.
+            if (_targetHovered && !root._clickActive) {
+                root._clickActive = true;
+            }
+        } else {
+            _evaluateStickyState();
+        }
+    }
 
     onActiveChanged: {
         if (!active) {
@@ -128,6 +142,28 @@ LazyLoader {
 
         WlrLayershell.namespace: "quickshell:popup"
         WlrLayershell.layer: WlrLayer.Overlay
+
+        HyprlandFocusGrab {
+            id: dismissGrab
+            windows: [popupWindow]
+            active: false
+            onCleared: () => {
+                root._clickActive = false;
+            }
+        }
+
+        Component.onCompleted: {
+            if (Config.options.bar.tooltips.clickToShow) {
+                // Delayed so the grab doesn't clear itself on the very click that opened the popup.
+                grabDelayTimer.start();
+            }
+        }
+
+        Timer {
+            id: grabDelayTimer
+            interval: Appearance.animation.elementMoveFast.duration
+            onTriggered: dismissGrab.active = true
+        }
 
         StyledRectangularShadow {
             target: popupBackground

--- a/dots/.config/quickshell/ii/modules/ii/bar/VerticalDashboardPanelButton.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/VerticalDashboardPanelButton.qml
@@ -21,7 +21,7 @@ RippleButton { // Right sidebar button
     bottomRightRadius: endRadius
 
     implicitHeight: indicatorsColumnLayout.implicitHeight + 8 * 2
-    implicitWidth: indicatorsColumnLayout.implicitWidth + 4 * 2
+    implicitWidth: Appearance.sizes.verticalBarWidth
 
     colBackgroundHover: Appearance.colors.colLayer1Hover
     colRipple: Appearance.colors.colLayer1Active

--- a/dots/.config/quickshell/ii/modules/ii/bar/weather/ExpressiveWeatherBar.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/weather/ExpressiveWeatherBar.qml
@@ -18,18 +18,20 @@ MouseArea {
     width: implicitWidth
     height: implicitHeight
 
-    acceptedButtons: Qt.LeftButton | Qt.RightButton
     hoverEnabled: !Config.options.bar.tooltips.clickToShow
 
-    onPressed: {
-        if (mouse.button === Qt.RightButton) {
+    // Separate right-click-only area so a right click never latches root.containsMouse
+    // (which would otherwise open the popup in click-to-show mode)
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.RightButton
+        onPressed: {
             Weather.getData();
             Quickshell.execDetached(["notify-send",
                 Translation.tr("Weather"),
                 Translation.tr("Refreshing (manually triggered)"),
                 "-a", "Shell"
             ])
-            mouse.accepted = false
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/bar/weather/WeatherBar.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/weather/WeatherBar.qml
@@ -15,18 +15,20 @@ MouseArea {
     implicitWidth: rowLayout.implicitWidth + 10 * 2.5
     implicitHeight: rowLayout.implicitHeight + 10 * 2
 
-    acceptedButtons: Qt.LeftButton | Qt.RightButton
     hoverEnabled: !Config.options.bar.tooltips.clickToShow
 
-    onPressed: {
-        if (mouse.button === Qt.RightButton) {
+    // Separate right-click-only area so a right click never latches root.containsMouse
+    // (which would otherwise open the popup in click-to-show mode)
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.RightButton
+        onPressed: {
             Weather.getData();
-            Quickshell.execDetached(["notify-send", 
-                Translation.tr("Weather"), 
+            Quickshell.execDetached(["notify-send",
+                Translation.tr("Weather"),
                 Translation.tr("Refreshing (manually triggered)")
                 , "-a", "Shell"
             ])
-            mouse.accepted = false
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/verticalBar/Resources.qml
+++ b/dots/.config/quickshell/ii/modules/ii/verticalBar/Resources.qml
@@ -1,34 +1,36 @@
-import qs.services
-import qs.modules.common
-import qs.modules.common.widgets
 import QtQuick
 import QtQuick.Layouts
+import qs.modules.common
+import qs.modules.common.widgets
 import qs.modules.ii.bar as Bar
+import qs.services
 
 MouseArea {
     id: root
+
     property bool alwaysShowAllResources: false
-
-    implicitWidth: mainCol.implicitWidth
-    implicitHeight: mainCol.implicitHeight
-    hoverEnabled: !Config.options.bar.tooltips.clickToShow
-
     readonly property color capsuleColor: {
         try {
             return rootItem.colBackground;
-        } catch(e) {
+        } catch (e) {
             return Appearance.colors.colLayer1;
         }
     }
 
+    implicitWidth: Appearance.sizes.verticalBarWidth
+    implicitHeight: mainCol.implicitHeight
+    hoverEnabled: !Config.options.bar.tooltips.clickToShow
+
     ColumnLayout {
         id: mainCol
+
         spacing: 6
         anchors.centerIn: parent
 
         // 1. Resources Capsule
         Rectangle {
             id: resourcesCapsule
+
             implicitWidth: Appearance.sizes.verticalBarWidth - 8
             implicitHeight: colLayout.implicitHeight + 10
             color: Config.options.bar.resources.showDocker ? root.capsuleColor : "transparent"
@@ -36,6 +38,7 @@ MouseArea {
 
             ColumnLayout {
                 id: colLayout
+
                 spacing: 6
                 anchors.centerIn: parent
 
@@ -76,26 +79,23 @@ MouseArea {
                     percentage: ResourceUsage.swapUsedPercentage
                     warningThreshold: Config.options.bar.resources.swapWarningThreshold
                 }
+
             }
+
         }
 
         // 2. Standalone Docker Vertical Capsule
         Rectangle {
             id: dockerCapsuleCol
+
             property bool shown: Config.options.bar.resources.showDocker && DockerService.dockerRunning
+
             visible: shown
             clip: true
             implicitWidth: Appearance.sizes.verticalBarWidth - 8
             implicitHeight: shown ? 40 : 0
             color: root.capsuleColor
             radius: Config.options.bar.barGroupStyle === 1 ? Appearance.rounding.windowRounding : Appearance.rounding.full
-
-            Behavior on implicitHeight {
-                NumberAnimation {
-                    duration: Appearance.animation.elementMove.duration
-                    easing.type: Appearance.animation.elementMove.type
-                }
-            }
 
             ColumnLayout {
                 spacing: 2
@@ -117,18 +117,30 @@ MouseArea {
                     font.weight: Font.Bold
                     color: Appearance.colors.colOnSurface
                 }
+
             }
+
+            Behavior on implicitHeight {
+                NumberAnimation {
+                    duration: Appearance.animation.elementMove.duration
+                    easing.type: Appearance.animation.elementMove.type
+                }
+
+            }
+
         }
+
     }
 
     Bar.ExpressiveResourcesPopup {
         hoverTarget: root
         Component.onCompleted: {
             activeChanged.connect(() => {
-                if (active) {
+                if (active)
                     DockerService.refreshForPopup();
-                }
+
             });
         }
     }
+
 }


### PR DESCRIPTION
## Describe your changes

Modified the "Click to show tooltip" option behaviour:
Now clicking on a widget (on the bar) make the popup appear and stays opened unless:
- Clicking again on the widget activation area
- Clicking anywhere else on the screen (except inside the popup itself—that won't close it)

Also fixed a few widgets that had a few pixels cut off of their activation area
So now they take up the whole width/height—depending on the bar position—so there are no small gaps left to miss the trigger

## Is it ready? Questions/feedback needed?

Should be ready, but probably some edge case with the "anywhere else on the screen" part—the rest is fine