### PR TITLE
feath(notifications): added notifications to ii lockscreen

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -940,6 +940,19 @@ Singleton {
                     property bool requirePasswordToPower: false
                 }
                 property bool materialShapeChars: true
+                property JsonObject notifications: JsonObject {
+                    property bool enable: false // Off by default: showing notifications on the lock screen is a privacy trade-off
+                    property string privacy: "redacted" // "full" | "redacted" | "countOnly"
+                    property bool onlySinceLock: true // Only show notifications that arrived while locked
+                    property int maxShown: 5
+                    property string appListMode: "blocklist" // "blocklist" | "allowlist"
+                    property list<string> appList: [] // App names, case-insensitive match
+                    property JsonObject filters: JsonObject {
+                        property bool skipTransient: true
+                        property bool skipLowUrgency: false
+                        property string criticalOverride: "full" // "full" | "none" — critical notifications bypass privacy redaction
+                    }
+                }
             }
 
             property JsonObject media: JsonObject {

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -946,8 +946,9 @@ Singleton {
                     property string privacy: "redacted" // "full" | "redacted" | "countOnly"
                     property bool onlySinceLock: true // Only show notifications that arrived while locked
                     property int maxShown: 5
-                    property string appListMode: "blocklist" // "blocklist" | "allowlist"
-                    property list<string> appList: [] // App names, case-insensitive match
+                    property string defaultPolicy: "show" // "show" | "hide" — apps without an explicit rule
+                    property list<string> alwaysShowApps: [] // App names, case-insensitive match
+                    property list<string> neverShowApps: []
                     property JsonObject filters: JsonObject {
                         property bool skipTransient: true
                         property bool skipLowUrgency: false

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -942,6 +942,7 @@ Singleton {
                 property bool materialShapeChars: true
                 property JsonObject notifications: JsonObject {
                     property bool enable: false // Off by default: showing notifications on the lock screen is a privacy trade-off
+                    property string position: "top_right" // "top_left" | "top_right" | "bottom_left" | "bottom_right"
                     property string privacy: "redacted" // "full" | "redacted" | "countOnly"
                     property bool onlySinceLock: true // Only show notifications that arrived while locked
                     property int maxShown: 5

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -946,6 +946,7 @@ Singleton {
                     property string privacy: "redacted" // "full" | "redacted" | "countOnly"
                     property bool onlySinceLock: true // Only show notifications that arrived while locked
                     property int maxShown: 5
+                    property int zoomPercent: 100 // 50-200, step 10
                     property string defaultPolicy: "show" // "show" | "hide" — apps without an explicit rule
                     property list<string> alwaysShowApps: [] // App names, case-insensitive match
                     property list<string> neverShowApps: []
@@ -973,6 +974,7 @@ Singleton {
             property JsonObject notifications: JsonObject {
                 property int timeout: 7000
                 property string position: "top_right"
+                property int zoomPercent: 100 // 50-200, step 10
                 property JsonObject monitor: JsonObject {
                     property bool enable: false
                     property string name: "" // Name of the monitor to show notifications on, like "eDP-1". Find out with 'hyprctl monitors' command

--- a/dots/.config/quickshell/ii/modules/common/widgets/NotificationGroup.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/NotificationGroup.qml
@@ -18,6 +18,7 @@ MouseArea { // Notification group area
     property bool multipleNotifications: notificationCount > 1
     property bool expanded: false
     property bool popup: false
+    property real zoom: 1.0
     property int lazyLimit: 2
 
     onExpandedChanged: {
@@ -45,7 +46,7 @@ MouseArea { // Notification group area
             }
         }
     }
-    property real padding: 10
+    property real padding: 10 * zoom
     implicitHeight: background.implicitHeight
 
     property real dragConfirmThreshold: 70 // Drag further to discard notification
@@ -174,7 +175,7 @@ MouseArea { // Notification group area
         anchors.left: parent.left
         width: parent.width
         color: popup ? Appearance.colors.colBackgroundSurfaceContainer : Appearance.colors.colLayer2
-        radius: Appearance.rounding.windowRounding
+        radius: Appearance.rounding.windowRounding * root.zoom
         anchors.leftMargin: root.xOffset
 
         opacity: {
@@ -202,7 +203,7 @@ MouseArea { // Notification group area
         }
 
         clip: true
-        implicitHeight: root.expanded ? row.implicitHeight + padding * 2 : Math.min(80, row.implicitHeight + padding * 2)
+        implicitHeight: root.expanded ? row.implicitHeight + padding * 2 : Math.min(80 * root.zoom, row.implicitHeight + padding * 2)
 
         Behavior on implicitHeight {
             id: implicitHeightAnim
@@ -215,11 +216,12 @@ MouseArea { // Notification group area
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.margins: root.padding
-            spacing: 10
+            spacing: 10 * root.zoom
 
             NotificationAppIcon { // Icons
                 Layout.alignment: Qt.AlignTop
                 Layout.fillWidth: false
+                implicitSize: 38 * root.zoom
                 image: root?.multipleNotifications ? "" : notificationGroup?.notifications[0]?.image ?? ""
                 appIcon: root.notificationGroup?.appIcon
                 summary: root.notificationGroup?.notifications[root.notificationCount - 1]?.summary
@@ -238,7 +240,7 @@ MouseArea { // Notification group area
                     id: topRow
                     // spacing: 0
                     Layout.fillWidth: true
-                    property real fontSize: Appearance.font.pixelSize.smaller
+                    property real fontSize: Appearance.font.pixelSize.smaller * root.zoom
                     property bool showAppName: root.multipleNotifications
                     implicitHeight: Math.max(topTextRow.implicitHeight, expandButton.implicitHeight)
 
@@ -253,7 +255,7 @@ MouseArea { // Notification group area
                             elide: Text.ElideRight
                             Layout.fillWidth: true
                             text: (topRow.showAppName ? notificationGroup?.appName : notificationGroup?.notifications[0]?.summary) || ""
-                            font.pixelSize: topRow.showAppName ? topRow.fontSize : Appearance.font.pixelSize.small
+                            font.pixelSize: topRow.showAppName ? topRow.fontSize : Appearance.font.pixelSize.small * root.zoom
                             color: topRow.showAppName ? Appearance.colors.colSubtext : Appearance.colors.colOnLayer2
                         }
                         StyledText {
@@ -272,7 +274,9 @@ MouseArea { // Notification group area
                         anchors.verticalCenter: parent.verticalCenter
                         count: root.notificationCount
                         expanded: root.expanded
+                        zoom: root.zoom
                         fontSize: topRow.fontSize
+                        iconSize: Appearance.font.pixelSize.normal * root.zoom
                         onClicked: {
                             root.toggleExpanded();
                         }
@@ -304,6 +308,7 @@ MouseArea { // Notification group area
                         required property var modelData
                         notificationObject: modelData
                         expanded: root.expanded
+                        zoom: root.zoom
                         onlyNotification: (root.notificationCount === 1)
                         opacity: (!root.expanded && index == 1 && root.notificationCount > 2) ? 0.5 : 1
                         visible: root.expanded || (index < 2)

--- a/dots/.config/quickshell/ii/modules/common/widgets/NotificationGroupExpandButton.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/NotificationGroupExpandButton.qml
@@ -8,10 +8,11 @@ RippleButton { // Expand button
     id: root
     required property int count
     required property bool expanded
+    property real zoom: 1.0
     property real fontSize: Appearance?.font.pixelSize.small ?? 12
     property real iconSize: Appearance?.font.pixelSize.normal ?? 16
-    implicitHeight: fontSize + 4 * 2
-    implicitWidth: Math.max(contentItem.implicitWidth + 5 * 2, 30)
+    implicitHeight: fontSize + 4 * 2 * zoom
+    implicitWidth: Math.max(contentItem.implicitWidth + 5 * 2 * zoom, 30 * zoom)
     Layout.alignment: Qt.AlignVCenter
     Layout.fillHeight: false
 
@@ -26,9 +27,9 @@ RippleButton { // Expand button
         RowLayout {
             id: contentRow
             anchors.centerIn: parent
-            spacing: 3
+            spacing: 3 * root.zoom
             StyledText {
-                Layout.leftMargin: 4
+                Layout.leftMargin: 4 * root.zoom
                 visible: root.count > 1
                 text: root.count
                 font.pixelSize: root.fontSize

--- a/dots/.config/quickshell/ii/modules/common/widgets/NotificationItem.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/NotificationItem.qml
@@ -14,8 +14,9 @@ Item { // Notification item area
     property var notificationObject
     property bool expanded: false
     property bool onlyNotification: false
-    property real fontSize: Appearance.font.pixelSize.small
-    property real padding: onlyNotification ? 0 : 8
+    property real zoom: 1.0
+    property real fontSize: Appearance.font.pixelSize.small * zoom
+    property real padding: onlyNotification ? 0 : 8 * zoom
     property real summaryElideRatio: 0.85
 
     property real dragConfirmThreshold: 70 // Drag further to discard notification
@@ -120,6 +121,7 @@ Item { // Notification item area
 
     NotificationAppIcon { // App icon
         id: notificationIcon
+        implicitSize: 38 * root.zoom
         opacity: (!onlyNotification && notificationObject.image != "" && expanded) ? 1 : 0
         visible: opacity > 0
 
@@ -137,7 +139,7 @@ Item { // Notification item area
         id: background
         width: parent.width
         anchors.left: parent.left
-        radius: Appearance.rounding.small
+        radius: Appearance.rounding.small * root.zoom
         anchors.leftMargin: root.xOffset
 
         opacity: {
@@ -253,7 +255,7 @@ Item { // Notification item area
                         maskSource: Rectangle {
                             width: actionsFlickable.width
                             height: actionsFlickable.height
-                            radius: Appearance.rounding.small
+                            radius: Appearance.rounding.small * root.zoom
                         }
                     }
 
@@ -286,6 +288,10 @@ Item { // Notification item area
                                 Layout.fillWidth: true
                                 buttonText: Translation.tr("Close")
                                 urgency: notificationObject.urgency
+                                implicitHeight: 34 * root.zoom
+                                leftPadding: 15 * root.zoom
+                                rightPadding: 15 * root.zoom
+                                buttonRadius: Appearance.rounding.small * root.zoom
                                 implicitWidth: (notificationObject.actions.length == 0) ? ((actionsFlickable.width - actionRowLayout.spacing) / 2) : (contentItem.implicitWidth + leftPadding + rightPadding)
 
                                 onClicked: {
@@ -293,7 +299,7 @@ Item { // Notification item area
                                 }
 
                                 contentItem: MaterialSymbol {
-                                    iconSize: Appearance.font.pixelSize.larger
+                                    iconSize: Appearance.font.pixelSize.larger * root.zoom
                                     horizontalAlignment: Text.AlignHCenter
                                     color: (notificationObject.urgency == NotificationUrgency.Critical) ? Appearance.m3colors.m3onSurfaceVariant : Appearance.m3colors.m3onSurface
                                     text: "close"
@@ -309,6 +315,10 @@ Item { // Notification item area
                                     Layout.fillWidth: true
                                     buttonText: modelData.text
                                     urgency: notificationObject.urgency
+                                    implicitHeight: 34 * root.zoom
+                                    leftPadding: 15 * root.zoom
+                                    rightPadding: 15 * root.zoom
+                                    buttonRadius: Appearance.rounding.small * root.zoom
                                     onClicked: {
                                         Notifications.attemptInvokeAction(notificationObject.notificationId, modelData.identifier);
                                     }
@@ -318,6 +328,10 @@ Item { // Notification item area
                             NotificationActionButton {
                                 Layout.fillWidth: true
                                 urgency: notificationObject.urgency
+                                implicitHeight: 34 * root.zoom
+                                leftPadding: 15 * root.zoom
+                                rightPadding: 15 * root.zoom
+                                buttonRadius: Appearance.rounding.small * root.zoom
                                 implicitWidth: (notificationObject.actions.length == 0) ? ((actionsFlickable.width - actionRowLayout.spacing) / 2) : (contentItem.implicitWidth + leftPadding + rightPadding)
 
                                 onClicked: {
@@ -337,7 +351,7 @@ Item { // Notification item area
 
                                 contentItem: MaterialSymbol {
                                     id: copyIcon
-                                    iconSize: Appearance.font.pixelSize.larger
+                                    iconSize: Appearance.font.pixelSize.larger * root.zoom
                                     horizontalAlignment: Text.AlignHCenter
                                     color: (notificationObject.urgency == NotificationUrgency.Critical) ? Appearance.m3colors.m3onSurfaceVariant : Appearance.m3colors.m3onSurface
                                     text: "content_copy"

--- a/dots/.config/quickshell/ii/modules/common/widgets/NotificationListView.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/NotificationListView.qml
@@ -9,6 +9,9 @@ import Quickshell
 StyledListView { // Scrollable window
     id: root
     property bool popup: false
+    // Only the floating popup is user-resizable; the sidebar notification
+    // center and phone mirror always render at their normal size.
+    readonly property real zoom: popup ? (Config.options.notifications.zoomPercent / 100) : 1.0
     dismissToLeft: popup && (Config.options.notifications.position ?? "top_right").endsWith("left")
     useSlideInAnimation: popup
 
@@ -21,6 +24,7 @@ StyledListView { // Scrollable window
         required property int index
         required property var modelData
         popup: root.popup
+        zoom: root.zoom
         width: ListView.view.width // https://doc.qt.io/qt-6/qml-qtquick-listview.html
         notificationGroup: popup ?
             Notifications.popupGroupsByAppName[modelData] :

--- a/dots/.config/quickshell/ii/modules/ii/lock/LockNotifications.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/LockNotifications.qml
@@ -31,8 +31,10 @@ ColumnLayout {
             return false;
         if (conf.filters.skipLowUrgency && notif.urgency === NotificationUrgency.Low.toString())
             return false;
-        const listed = conf.appList.some(app => app.toLowerCase() === notif.appName.toLowerCase());
-        if (conf.appListMode === "blocklist" ? listed : !listed)
+        const appName = notif.appName.toLowerCase();
+        if (conf.neverShowApps.some(app => app.toLowerCase() === appName))
+            return false;
+        if (conf.defaultPolicy === "hide" && !conf.alwaysShowApps.some(app => app.toLowerCase() === appName))
             return false;
         return true;
     }).sort((a, b) => b.time - a.time)

--- a/dots/.config/quickshell/ii/modules/ii/lock/LockNotifications.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/LockNotifications.qml
@@ -1,0 +1,244 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import QtQuick.Layouts
+import Quickshell.Services.Notifications
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+
+/**
+ * Read-only notification list for the lock screen.
+ * Strictly display-only: no actions, no dismissal, no mouse handling,
+ * so the lock surface keeps forcing focus on the password box.
+ */
+ColumnLayout {
+    id: root
+
+    readonly property var conf: Config.options.lock.notifications
+    readonly property string criticalUrgency: NotificationUrgency.Critical.toString()
+
+    property double lockTime: 0
+    // The Loader in LockSurface activates when the session gets locked
+    Component.onCompleted: lockTime = Date.now()
+
+    readonly property var filtered: Notifications.list.filter(notif => {
+        if (conf.onlySinceLock && notif.time < root.lockTime)
+            return false;
+        if (conf.filters.skipTransient && notif.isTransient)
+            return false;
+        if (conf.filters.skipLowUrgency && notif.urgency === NotificationUrgency.Low.toString())
+            return false;
+        const listed = conf.appList.some(app => app.toLowerCase() === notif.appName.toLowerCase());
+        if (conf.appListMode === "blocklist" ? listed : !listed)
+            return false;
+        return true;
+    }).sort((a, b) => b.time - a.time)
+
+    // Notifications rendered with full content: everything in "full" mode,
+    // otherwise only critical ones when the override allows them through
+    readonly property var fullyShown: {
+        if (conf.privacy === "full")
+            return filtered.slice(0, conf.maxShown);
+        if (conf.filters.criticalOverride === "full")
+            return filtered.filter(n => n.urgency === root.criticalUrgency).slice(0, conf.maxShown);
+        return [];
+    }
+    readonly property var redactedRest: filtered.filter(n => !fullyShown.includes(n))
+    readonly property var redactedGroups: {
+        if (conf.privacy !== "redacted")
+            return [];
+        const groups = [];
+        redactedRest.forEach(notif => {
+            let group = groups.find(g => g.appName === notif.appName);
+            if (!group) {
+                group = {
+                    appName: notif.appName,
+                    appIcon: notif.appIcon,
+                    count: 0
+                };
+                groups.push(group);
+            }
+            group.count += 1;
+        });
+        return groups.slice(0, Math.max(0, conf.maxShown - fullyShown.length));
+    }
+    readonly property int overflowCount: {
+        if (conf.privacy === "full")
+            return filtered.length - fullyShown.length;
+        if (conf.privacy === "redacted")
+            return redactedRest.filter(n => !redactedGroups.some(g => g.appName === n.appName)).length;
+        return 0; // The count pill already covers every remaining notification
+    }
+
+    width: 380
+    spacing: 8
+    visible: filtered.length > 0
+
+    Repeater {
+        model: root.fullyShown
+        delegate: FullCard {}
+    }
+
+    Repeater {
+        model: root.redactedGroups
+        delegate: RedactedCard {}
+    }
+
+    Loader {
+        Layout.alignment: Qt.AlignRight
+        active: root.conf.privacy === "countOnly" && root.redactedRest.length > 0
+        visible: active
+        sourceComponent: CountPill {}
+    }
+
+    Loader {
+        Layout.alignment: Qt.AlignRight
+        Layout.rightMargin: 10
+        active: root.overflowCount > 0
+        visible: active
+        sourceComponent: StyledText {
+            text: Translation.tr("+%1 more").arg(root.overflowCount)
+            font.pixelSize: Appearance.font.pixelSize.small
+            color: Appearance.colors.colOnSurfaceVariant
+        }
+    }
+
+    component Card: Rectangle {
+        radius: Appearance.rounding.normal
+        color: ColorUtils.transparentize(Appearance.m3colors.m3surfaceContainer, 0.08)
+    }
+
+    component FullCard: Card {
+        id: fullCard
+        required property var modelData
+
+        Layout.fillWidth: true
+        implicitHeight: fullCardRow.implicitHeight + 20
+
+        RowLayout {
+            id: fullCardRow
+            anchors {
+                fill: parent
+                margins: 10
+            }
+            spacing: 10
+
+            NotificationAppIcon {
+                Layout.alignment: Qt.AlignTop
+                appIcon: fullCard.modelData.appIcon
+                summary: fullCard.modelData.summary
+                image: fullCard.modelData.image
+                urgency: fullCard.modelData.urgency === root.criticalUrgency ? NotificationUrgency.Critical : NotificationUrgency.Normal
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 2
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 6
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: fullCard.modelData.appName
+                        elide: Text.ElideRight
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: Appearance.colors.colOnSurfaceVariant
+                    }
+                    StyledText {
+                        text: NotificationUtils.getFriendlyNotifTimeString(fullCard.modelData.time)
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: Appearance.colors.colOnSurfaceVariant
+                    }
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: fullCard.modelData.summary
+                    textFormat: Text.PlainText
+                    elide: Text.ElideRight
+                    font.weight: Font.Medium
+                    color: Appearance.colors.colOnLayer1
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    visible: text.length > 0
+                    text: fullCard.modelData.body
+                    textFormat: Text.PlainText
+                    wrapMode: Text.Wrap
+                    elide: Text.ElideRight
+                    maximumLineCount: 2
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colOnSurfaceVariant
+                }
+            }
+        }
+    }
+
+    component RedactedCard: Card {
+        id: redactedCard
+        required property var modelData
+
+        Layout.fillWidth: true
+        implicitHeight: redactedCardRow.implicitHeight + 20
+
+        RowLayout {
+            id: redactedCardRow
+            anchors {
+                fill: parent
+                margins: 10
+            }
+            spacing: 10
+
+            NotificationAppIcon {
+                appIcon: redactedCard.modelData.appIcon
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 2
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: redactedCard.modelData.appName
+                    elide: Text.ElideRight
+                    font.weight: Font.Medium
+                    color: Appearance.colors.colOnLayer1
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    text: redactedCard.modelData.count === 1 ? Translation.tr("1 new notification") : Translation.tr("%1 new notifications").arg(redactedCard.modelData.count)
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colOnSurfaceVariant
+                }
+            }
+        }
+    }
+
+    component CountPill: Card {
+        implicitWidth: pillRow.implicitWidth + 28
+        implicitHeight: pillRow.implicitHeight + 14
+        radius: Appearance.rounding.full
+
+        RowLayout {
+            id: pillRow
+            anchors.centerIn: parent
+            spacing: 6
+
+            MaterialSymbol {
+                fill: 1
+                text: "notifications"
+                iconSize: Appearance.font.pixelSize.huge
+                color: Appearance.colors.colOnSurfaceVariant
+            }
+            StyledText {
+                text: root.redactedRest.length
+                font.weight: Font.Medium
+                color: Appearance.colors.colOnLayer1
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/lock/LockNotifications.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/LockNotifications.qml
@@ -17,6 +17,8 @@ ColumnLayout {
 
     readonly property var conf: Config.options.lock.notifications
     readonly property string criticalUrgency: NotificationUrgency.Critical.toString()
+    readonly property bool onTop: conf.position.startsWith("top")
+    readonly property bool onLeft: conf.position.endsWith("left")
 
     property double lockTime: 0
     // The Loader in LockSurface activates when the session gets locked
@@ -71,36 +73,80 @@ ColumnLayout {
         return 0; // The count pill already covers every remaining notification
     }
 
+    // Flat, ordered list of everything to render. Newest sits closest to the
+    // screen edge: stacking is newest-first on top, flipped when on the bottom
+    readonly property var displayItems: {
+        const items = fullyShown.map(notif => ({
+            kind: "full",
+            notif: notif
+        }));
+        redactedGroups.forEach(group => items.push({
+            kind: "redacted",
+            group: group
+        }));
+        if (conf.privacy === "countOnly" && redactedRest.length > 0)
+            items.push({
+                kind: "countPill"
+            });
+        if (overflowCount > 0)
+            items.push({
+                kind: "overflow"
+            });
+        return onTop ? items : items.reverse();
+    }
+
     width: 380
     spacing: 8
     visible: filtered.length > 0
 
     Repeater {
-        model: root.fullyShown
-        delegate: FullCard {}
-    }
+        model: root.displayItems
+        delegate: Loader {
+            id: itemLoader
+            required property var modelData
+            readonly property bool isCard: modelData.kind === "full" || modelData.kind === "redacted"
 
-    Repeater {
-        model: root.redactedGroups
-        delegate: RedactedCard {}
-    }
+            Layout.fillWidth: isCard
+            Layout.alignment: root.onLeft ? Qt.AlignLeft : Qt.AlignRight
+            Layout.leftMargin: (!isCard && root.onLeft) ? 10 : 0
+            Layout.rightMargin: (!isCard && !root.onLeft) ? 10 : 0
+            sourceComponent: {
+                switch (itemLoader.modelData.kind) {
+                case "full":
+                    return fullComponent;
+                case "redacted":
+                    return redactedComponent;
+                case "countPill":
+                    return pillComponent;
+                default:
+                    return overflowComponent;
+                }
+            }
 
-    Loader {
-        Layout.alignment: Qt.AlignRight
-        active: root.conf.privacy === "countOnly" && root.redactedRest.length > 0
-        visible: active
-        sourceComponent: CountPill {}
-    }
-
-    Loader {
-        Layout.alignment: Qt.AlignRight
-        Layout.rightMargin: 10
-        active: root.overflowCount > 0
-        visible: active
-        sourceComponent: StyledText {
-            text: Translation.tr("+%1 more").arg(root.overflowCount)
-            font.pixelSize: Appearance.font.pixelSize.small
-            color: Appearance.colors.colOnSurfaceVariant
+            Component {
+                id: fullComponent
+                FullCard {
+                    notif: itemLoader.modelData.notif
+                }
+            }
+            Component {
+                id: redactedComponent
+                RedactedCard {
+                    group: itemLoader.modelData.group
+                }
+            }
+            Component {
+                id: pillComponent
+                CountPill {}
+            }
+            Component {
+                id: overflowComponent
+                StyledText {
+                    text: Translation.tr("+%1 more").arg(root.overflowCount)
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    color: Appearance.colors.colOnSurfaceVariant
+                }
+            }
         }
     }
 
@@ -111,9 +157,8 @@ ColumnLayout {
 
     component FullCard: Card {
         id: fullCard
-        required property var modelData
+        required property var notif
 
-        Layout.fillWidth: true
         implicitHeight: fullCardRow.implicitHeight + 20
 
         RowLayout {
@@ -126,10 +171,10 @@ ColumnLayout {
 
             NotificationAppIcon {
                 Layout.alignment: Qt.AlignTop
-                appIcon: fullCard.modelData.appIcon
-                summary: fullCard.modelData.summary
-                image: fullCard.modelData.image
-                urgency: fullCard.modelData.urgency === root.criticalUrgency ? NotificationUrgency.Critical : NotificationUrgency.Normal
+                appIcon: fullCard.notif.appIcon
+                summary: fullCard.notif.summary
+                image: fullCard.notif.image
+                urgency: fullCard.notif.urgency === root.criticalUrgency ? NotificationUrgency.Critical : NotificationUrgency.Normal
             }
 
             ColumnLayout {
@@ -142,13 +187,13 @@ ColumnLayout {
 
                     StyledText {
                         Layout.fillWidth: true
-                        text: fullCard.modelData.appName
+                        text: fullCard.notif.appName
                         elide: Text.ElideRight
                         font.pixelSize: Appearance.font.pixelSize.smaller
                         color: Appearance.colors.colOnSurfaceVariant
                     }
                     StyledText {
-                        text: NotificationUtils.getFriendlyNotifTimeString(fullCard.modelData.time)
+                        text: NotificationUtils.getFriendlyNotifTimeString(fullCard.notif.time)
                         font.pixelSize: Appearance.font.pixelSize.smaller
                         color: Appearance.colors.colOnSurfaceVariant
                     }
@@ -156,7 +201,7 @@ ColumnLayout {
 
                 StyledText {
                     Layout.fillWidth: true
-                    text: fullCard.modelData.summary
+                    text: fullCard.notif.summary
                     textFormat: Text.PlainText
                     elide: Text.ElideRight
                     font.weight: Font.Medium
@@ -166,7 +211,7 @@ ColumnLayout {
                 StyledText {
                     Layout.fillWidth: true
                     visible: text.length > 0
-                    text: fullCard.modelData.body
+                    text: fullCard.notif.body
                     textFormat: Text.PlainText
                     wrapMode: Text.Wrap
                     elide: Text.ElideRight
@@ -180,9 +225,8 @@ ColumnLayout {
 
     component RedactedCard: Card {
         id: redactedCard
-        required property var modelData
+        required property var group
 
-        Layout.fillWidth: true
         implicitHeight: redactedCardRow.implicitHeight + 20
 
         RowLayout {
@@ -194,7 +238,7 @@ ColumnLayout {
             spacing: 10
 
             NotificationAppIcon {
-                appIcon: redactedCard.modelData.appIcon
+                appIcon: redactedCard.group.appIcon
             }
 
             ColumnLayout {
@@ -203,14 +247,14 @@ ColumnLayout {
 
                 StyledText {
                     Layout.fillWidth: true
-                    text: redactedCard.modelData.appName
+                    text: redactedCard.group.appName
                     elide: Text.ElideRight
                     font.weight: Font.Medium
                     color: Appearance.colors.colOnLayer1
                 }
                 StyledText {
                     Layout.fillWidth: true
-                    text: redactedCard.modelData.count === 1 ? Translation.tr("1 new notification") : Translation.tr("%1 new notifications").arg(redactedCard.modelData.count)
+                    text: redactedCard.group.count === 1 ? Translation.tr("1 new notification") : Translation.tr("%1 new notifications").arg(redactedCard.group.count)
                     font.pixelSize: Appearance.font.pixelSize.smaller
                     color: Appearance.colors.colOnSurfaceVariant
                 }

--- a/dots/.config/quickshell/ii/modules/ii/lock/LockNotifications.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/LockNotifications.qml
@@ -19,6 +19,7 @@ ColumnLayout {
     readonly property string criticalUrgency: NotificationUrgency.Critical.toString()
     readonly property bool onTop: conf.position.startsWith("top")
     readonly property bool onLeft: conf.position.endsWith("left")
+    readonly property real zoom: conf.zoomPercent / 100
 
     property double lockTime: 0
     // The Loader in LockSurface activates when the session gets locked
@@ -97,7 +98,7 @@ ColumnLayout {
         return onTop ? items : items.reverse();
     }
 
-    width: 380
+    width: 380 * zoom
     spacing: 8
     visible: filtered.length > 0
 
@@ -145,7 +146,7 @@ ColumnLayout {
                 id: overflowComponent
                 StyledText {
                     text: Translation.tr("+%1 more").arg(root.overflowCount)
-                    font.pixelSize: Appearance.font.pixelSize.small
+                    font.pixelSize: Appearance.font.pixelSize.small * root.zoom
                     color: Appearance.colors.colOnSurfaceVariant
                 }
             }
@@ -153,7 +154,7 @@ ColumnLayout {
     }
 
     component Card: Rectangle {
-        radius: Appearance.rounding.normal
+        radius: Appearance.rounding.normal * root.zoom
         color: ColorUtils.transparentize(Appearance.m3colors.m3surfaceContainer, 0.08)
     }
 
@@ -161,18 +162,19 @@ ColumnLayout {
         id: fullCard
         required property var notif
 
-        implicitHeight: fullCardRow.implicitHeight + 20
+        implicitHeight: fullCardRow.implicitHeight + 20 * root.zoom
 
         RowLayout {
             id: fullCardRow
             anchors {
                 fill: parent
-                margins: 10
+                margins: 10 * root.zoom
             }
-            spacing: 10
+            spacing: 10 * root.zoom
 
             NotificationAppIcon {
                 Layout.alignment: Qt.AlignTop
+                implicitSize: 38 * root.zoom
                 appIcon: fullCard.notif.appIcon
                 summary: fullCard.notif.summary
                 image: fullCard.notif.image
@@ -181,22 +183,22 @@ ColumnLayout {
 
             ColumnLayout {
                 Layout.fillWidth: true
-                spacing: 2
+                spacing: 2 * root.zoom
 
                 RowLayout {
                     Layout.fillWidth: true
-                    spacing: 6
+                    spacing: 6 * root.zoom
 
                     StyledText {
                         Layout.fillWidth: true
                         text: fullCard.notif.appName
                         elide: Text.ElideRight
-                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        font.pixelSize: Appearance.font.pixelSize.smaller * root.zoom
                         color: Appearance.colors.colOnSurfaceVariant
                     }
                     StyledText {
                         text: NotificationUtils.getFriendlyNotifTimeString(fullCard.notif.time)
-                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        font.pixelSize: Appearance.font.pixelSize.smaller * root.zoom
                         color: Appearance.colors.colOnSurfaceVariant
                     }
                 }
@@ -207,6 +209,7 @@ ColumnLayout {
                     textFormat: Text.PlainText
                     elide: Text.ElideRight
                     font.weight: Font.Medium
+                    font.pixelSize: Appearance.font.pixelSize.small * root.zoom
                     color: Appearance.colors.colOnLayer1
                 }
 
@@ -218,7 +221,7 @@ ColumnLayout {
                     wrapMode: Text.Wrap
                     elide: Text.ElideRight
                     maximumLineCount: 2
-                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    font.pixelSize: Appearance.font.pixelSize.smaller * root.zoom
                     color: Appearance.colors.colOnSurfaceVariant
                 }
             }
@@ -229,35 +232,37 @@ ColumnLayout {
         id: redactedCard
         required property var group
 
-        implicitHeight: redactedCardRow.implicitHeight + 20
+        implicitHeight: redactedCardRow.implicitHeight + 20 * root.zoom
 
         RowLayout {
             id: redactedCardRow
             anchors {
                 fill: parent
-                margins: 10
+                margins: 10 * root.zoom
             }
-            spacing: 10
+            spacing: 10 * root.zoom
 
             NotificationAppIcon {
+                implicitSize: 38 * root.zoom
                 appIcon: redactedCard.group.appIcon
             }
 
             ColumnLayout {
                 Layout.fillWidth: true
-                spacing: 2
+                spacing: 2 * root.zoom
 
                 StyledText {
                     Layout.fillWidth: true
                     text: redactedCard.group.appName
                     elide: Text.ElideRight
                     font.weight: Font.Medium
+                    font.pixelSize: Appearance.font.pixelSize.small * root.zoom
                     color: Appearance.colors.colOnLayer1
                 }
                 StyledText {
                     Layout.fillWidth: true
                     text: redactedCard.group.count === 1 ? Translation.tr("1 new notification") : Translation.tr("%1 new notifications").arg(redactedCard.group.count)
-                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    font.pixelSize: Appearance.font.pixelSize.smaller * root.zoom
                     color: Appearance.colors.colOnSurfaceVariant
                 }
             }
@@ -265,24 +270,25 @@ ColumnLayout {
     }
 
     component CountPill: Card {
-        implicitWidth: pillRow.implicitWidth + 28
-        implicitHeight: pillRow.implicitHeight + 14
+        implicitWidth: pillRow.implicitWidth + 28 * root.zoom
+        implicitHeight: pillRow.implicitHeight + 14 * root.zoom
         radius: Appearance.rounding.full
 
         RowLayout {
             id: pillRow
             anchors.centerIn: parent
-            spacing: 6
+            spacing: 6 * root.zoom
 
             MaterialSymbol {
                 fill: 1
                 text: "notifications"
-                iconSize: Appearance.font.pixelSize.huge
+                iconSize: Appearance.font.pixelSize.huge * root.zoom
                 color: Appearance.colors.colOnSurfaceVariant
             }
             StyledText {
                 text: root.redactedRest.length
                 font.weight: Font.Medium
+                font.pixelSize: Appearance.font.pixelSize.small * root.zoom
                 color: Appearance.colors.colOnLayer1
             }
         }

--- a/dots/.config/quickshell/ii/modules/ii/lock/LockSurface.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/LockSurface.qml
@@ -9,6 +9,7 @@ import qs.modules.common.widgets
 import qs.modules.common.functions
 import qs.modules.common.panels.lock
 import qs.modules.ii.bar as Bar
+import qs.modules.ii.bar.widgets.tray
 import Quickshell
 import Quickshell.Services.SystemTray
 
@@ -295,7 +296,7 @@ MouseArea {
         }
 
         // Keyboard layout (Fcitx)
-        Bar.SysTray {
+        SysTray {
             Layout.rightMargin: 10
             Layout.alignment: Qt.AlignVCenter
             showSeparator: false

--- a/dots/.config/quickshell/ii/modules/ii/lock/LockSurface.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/LockSurface.qml
@@ -96,6 +96,19 @@ MouseArea {
     //     }
     // }
 
+    // Notifications (read-only)
+    Loader {
+        anchors {
+            top: parent.top
+            right: parent.right
+            margins: 20
+        }
+        active: Config.options.lock.notifications.enable
+        scale: root.toolbarScale
+        opacity: root.toolbarOpacity
+        sourceComponent: LockNotifications {}
+    }
+
     // Main toolbar: password box
     Toolbar {
         id: mainIsland

--- a/dots/.config/quickshell/ii/modules/ii/lock/LockSurface.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/LockSurface.qml
@@ -98,9 +98,13 @@ MouseArea {
 
     // Notifications (read-only)
     Loader {
+        readonly property bool notifsOnTop: Config.options.lock.notifications.position.startsWith("top")
+        readonly property bool notifsOnLeft: Config.options.lock.notifications.position.endsWith("left")
         anchors {
-            top: parent.top
-            right: parent.right
+            top: notifsOnTop ? parent.top : undefined
+            bottom: notifsOnTop ? undefined : parent.bottom
+            left: notifsOnLeft ? parent.left : undefined
+            right: notifsOnLeft ? undefined : parent.right
             margins: 20
         }
         active: Config.options.lock.notifications.enable

--- a/dots/.config/quickshell/ii/modules/ii/notificationPopup/NotificationPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/notificationPopup/NotificationPopup.qml
@@ -74,7 +74,7 @@ Scope {
             anchors.rightMargin: root.isRight ? Math.max(Appearance.sizes.hyprlandGapsOut, Appearance.rounding.windowRounding * 0.5) : 0
             anchors.topMargin: Math.max(Appearance.sizes.hyprlandGapsOut, Appearance.rounding.windowRounding * 0.5)
             anchors.bottomMargin: Math.max(Appearance.sizes.hyprlandGapsOut, Appearance.rounding.windowRounding * 0.5)
-            width: Appearance.sizes.notificationPopupWidth
+            width: Appearance.sizes.notificationPopupWidth * (Config.options.notifications.zoomPercent / 100)
             popup: true
             height: Math.min(contentItem.height + anchors.topMargin + anchors.bottomMargin, parent.height)
             verticalLayoutDirection: root.isBottom ? ListView.BottomToTop : ListView.TopToBottom

--- a/dots/.config/quickshell/ii/modules/settings/configs/LockScreenConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/LockScreenConfig.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts
 import QtQuick.Controls
 import Quickshell
 import Quickshell.Io
+import Quickshell.Widgets
 import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
@@ -172,38 +173,11 @@ ContentPage {
         }
 
         ContentSubsection {
-            title: Translation.tr("App list")
+            title: Translation.tr("App rules")
             icon: "apps"
             Layout.fillWidth: true
 
-            ConfigSelectionArray {
-                currentValue: Config.options.lock.notifications.appListMode
-                onSelected: newValue => {
-                    Config.options.lock.notifications.appListMode = newValue;
-                }
-                options: [
-                    {
-                        displayName: Translation.tr("Blocklist"),
-                        icon: "block",
-                        value: "blocklist"
-                    },
-                    {
-                        displayName: Translation.tr("Allowlist"),
-                        icon: "check_circle",
-                        value: "allowlist"
-                    }
-                ]
-            }
-
-            MaterialTextArea {
-                Layout.fillWidth: true
-                placeholderText: Translation.tr("App names, one per line")
-                wrapMode: TextEdit.NoWrap
-                Component.onCompleted: text = Config.options.lock.notifications.appList.join("\n")
-                onTextChanged: {
-                    Config.options.lock.notifications.appList = text.split("\n").map(line => line.trim()).filter(line => line.length > 0);
-                }
-            }
+            AppRulesEditor {}
         }
 
         ContentSubsection {
@@ -293,6 +267,145 @@ ContentPage {
             }
             StyledToolTip {
                 text: Translation.tr("Replace the standard dots with random Material You shapes when typing the password.")
+            }
+        }
+    }
+
+    component AppRulesEditor: ColumnLayout {
+        id: editor
+
+        readonly property var conf: Config.options.lock.notifications
+        readonly property string query: searchField.text.trim()
+
+        function ruleFor(name) {
+            const lower = name.toLowerCase();
+            if (conf.neverShowApps.some(app => app.toLowerCase() === lower))
+                return "hide";
+            if (conf.alwaysShowApps.some(app => app.toLowerCase() === lower))
+                return "show";
+            return "default";
+        }
+
+        function setRule(name, rule) {
+            const lower = name.toLowerCase();
+            conf.alwaysShowApps = conf.alwaysShowApps.filter(app => app.toLowerCase() !== lower);
+            conf.neverShowApps = conf.neverShowApps.filter(app => app.toLowerCase() !== lower);
+            if (rule === "show")
+                conf.alwaysShowApps = [...conf.alwaysShowApps, name];
+            else if (rule === "hide")
+                conf.neverShowApps = [...conf.neverShowApps, name];
+        }
+
+        // Apps with explicit rules, then (while searching) installed apps and
+        // the raw query as a free-text fallback, since notification app names
+        // can differ from any desktop entry
+        readonly property var displayedApps: {
+            const lowerQuery = query.toLowerCase();
+            const taken = new Set();
+            const result = [];
+            const add = (name, icon) => {
+                if (!name || taken.has(name.toLowerCase()))
+                    return;
+                taken.add(name.toLowerCase());
+                result.push({
+                    name: name,
+                    icon: icon
+                });
+            };
+            const matches = name => lowerQuery === "" || name.toLowerCase().includes(lowerQuery);
+
+            [...conf.alwaysShowApps, ...conf.neverShowApps].filter(matches).forEach(name => add(name, ""));
+            if (lowerQuery !== "") {
+                AppSearch.fuzzyQuery(query).slice(0, 8).forEach(entry => add(entry.name, entry.icon));
+                add(query, "");
+            }
+            return result;
+        }
+
+        spacing: 8
+
+        ConfigSelectionArray {
+            currentValue: editor.conf.defaultPolicy
+            onSelected: newValue => {
+                editor.conf.defaultPolicy = newValue;
+            }
+            options: [
+                {
+                    displayName: Translation.tr("Show by default"),
+                    icon: "visibility",
+                    value: "show"
+                },
+                {
+                    displayName: Translation.tr("Hide by default"),
+                    icon: "visibility_off",
+                    value: "hide"
+                }
+            ]
+        }
+
+        MaterialTextField {
+            id: searchField
+            Layout.fillWidth: true
+            placeholderText: Translation.tr("Search apps or type a name")
+        }
+
+        StyledText {
+            visible: editor.displayedApps.length === 0
+            Layout.fillWidth: true
+            text: Translation.tr("No rules yet. Search to pick an installed app, or type any name a notification reports.")
+            wrapMode: Text.Wrap
+            font.pixelSize: Appearance.font.pixelSize.smaller
+            color: Appearance.colors.colSubtext
+        }
+
+        Repeater {
+            model: editor.displayedApps
+            delegate: RowLayout {
+                id: appRow
+                required property var modelData
+                readonly property string rule: editor.ruleFor(modelData.name)
+
+                Layout.fillWidth: true
+                spacing: 10
+
+                IconImage {
+                    implicitSize: 28
+                    source: Quickshell.iconPath(appRow.modelData.icon !== "" ? appRow.modelData.icon : AppSearch.guessIcon(appRow.modelData.name), "image-missing")
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: appRow.modelData.name
+                    elide: Text.ElideRight
+                    color: Appearance.colors.colOnSecondaryContainer
+                }
+
+                SelectionGroupButton {
+                    leftmost: true
+                    buttonIcon: "remove"
+                    toggled: appRow.rule === "default"
+                    onClicked: editor.setRule(appRow.modelData.name, "default")
+                    StyledToolTip {
+                        text: Translation.tr("Follow default")
+                    }
+                }
+                SelectionGroupButton {
+                    buttonIcon: "visibility"
+                    toggled: appRow.rule === "show"
+                    onClicked: editor.setRule(appRow.modelData.name, "show")
+                    StyledToolTip {
+                        text: Translation.tr("Always show")
+                    }
+                }
+                SelectionGroupButton {
+                    rightmost: true
+                    buttonIcon: "visibility_off"
+                    toggled: appRow.rule === "hide"
+                    onClicked: editor.setRule(appRow.modelData.name, "hide")
+                    StyledToolTip {
+                        text: Translation.tr("Never show")
+                    }
+                }
             }
         }
     }

--- a/dots/.config/quickshell/ii/modules/settings/configs/LockScreenConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/LockScreenConfig.qml
@@ -70,6 +70,158 @@ ContentPage {
     }
 
     ContentSection {
+        icon: "notifications"
+        title: Translation.tr("Notifications")
+
+        ConfigSwitch {
+            buttonIcon: "notifications"
+            text: Translation.tr("Show notifications on lock screen")
+            checked: Config.options.lock.notifications.enable
+            onCheckedChanged: {
+                Config.options.lock.notifications.enable = checked;
+            }
+            StyledToolTip {
+                text: Translation.tr("Anyone with physical access to the machine will be able to see them.")
+            }
+        }
+
+        ContentSubsection {
+            title: Translation.tr("Privacy level")
+            icon: "visibility"
+            Layout.fillWidth: true
+
+            ConfigSelectionArray {
+                currentValue: Config.options.lock.notifications.privacy
+                onSelected: newValue => {
+                    Config.options.lock.notifications.privacy = newValue;
+                }
+                options: [
+                    {
+                        displayName: Translation.tr("Full content"),
+                        icon: "visibility",
+                        value: "full"
+                    },
+                    {
+                        displayName: Translation.tr("Hide content"),
+                        icon: "visibility_off",
+                        value: "redacted"
+                    },
+                    {
+                        displayName: Translation.tr("Count only"),
+                        icon: "numbers",
+                        value: "countOnly"
+                    }
+                ]
+            }
+        }
+
+        ConfigSwitch {
+            buttonIcon: "history"
+            text: Translation.tr("Only notifications received while locked")
+            checked: Config.options.lock.notifications.onlySinceLock
+            onCheckedChanged: {
+                Config.options.lock.notifications.onlySinceLock = checked;
+            }
+        }
+
+        ConfigSpinBox {
+            icon: "format_list_numbered"
+            text: Translation.tr("Maximum notifications shown")
+            value: Config.options.lock.notifications.maxShown
+            from: 1
+            to: 10
+            stepSize: 1
+            onValueChanged: {
+                Config.options.lock.notifications.maxShown = value;
+            }
+        }
+
+        ContentSubsection {
+            title: Translation.tr("App list")
+            icon: "apps"
+            Layout.fillWidth: true
+
+            ConfigSelectionArray {
+                currentValue: Config.options.lock.notifications.appListMode
+                onSelected: newValue => {
+                    Config.options.lock.notifications.appListMode = newValue;
+                }
+                options: [
+                    {
+                        displayName: Translation.tr("Blocklist"),
+                        icon: "block",
+                        value: "blocklist"
+                    },
+                    {
+                        displayName: Translation.tr("Allowlist"),
+                        icon: "check_circle",
+                        value: "allowlist"
+                    }
+                ]
+            }
+
+            MaterialTextArea {
+                Layout.fillWidth: true
+                placeholderText: Translation.tr("App names, one per line")
+                wrapMode: TextEdit.NoWrap
+                Component.onCompleted: text = Config.options.lock.notifications.appList.join("\n")
+                onTextChanged: {
+                    Config.options.lock.notifications.appList = text.split("\n").map(line => line.trim()).filter(line => line.length > 0);
+                }
+            }
+        }
+
+        ContentSubsection {
+            title: Translation.tr("Filters")
+            icon: "filter_alt"
+            Layout.fillWidth: true
+
+            ConfigSwitch {
+                buttonIcon: "hourglass_disabled"
+                text: Translation.tr("Hide transient notifications")
+                checked: Config.options.lock.notifications.filters.skipTransient
+                onCheckedChanged: {
+                    Config.options.lock.notifications.filters.skipTransient = checked;
+                }
+            }
+
+            ConfigSwitch {
+                buttonIcon: "low_priority"
+                text: Translation.tr("Hide low-urgency notifications")
+                checked: Config.options.lock.notifications.filters.skipLowUrgency
+                onCheckedChanged: {
+                    Config.options.lock.notifications.filters.skipLowUrgency = checked;
+                }
+            }
+        }
+
+        ContentSubsection {
+            title: Translation.tr("Critical notifications")
+            icon: "priority_high"
+            Layout.fillWidth: true
+
+            ConfigSelectionArray {
+                currentValue: Config.options.lock.notifications.filters.criticalOverride
+                onSelected: newValue => {
+                    Config.options.lock.notifications.filters.criticalOverride = newValue;
+                }
+                options: [
+                    {
+                        displayName: Translation.tr("Always show full"),
+                        icon: "priority_high",
+                        value: "full"
+                    },
+                    {
+                        displayName: Translation.tr("No exception"),
+                        icon: "do_not_disturb_on",
+                        value: "none"
+                    }
+                ]
+            }
+        }
+    }
+
+    ContentSection {
         icon: "style"
         title: Translation.tr("Style: General")
 

--- a/dots/.config/quickshell/ii/modules/settings/configs/LockScreenConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/LockScreenConfig.qml
@@ -86,6 +86,41 @@ ContentPage {
         }
 
         ContentSubsection {
+            title: Translation.tr("Position")
+            icon: "picture_in_picture"
+            Layout.fillWidth: true
+
+            ConfigSelectionArray {
+                currentValue: Config.options.lock.notifications.position
+                onSelected: newValue => {
+                    Config.options.lock.notifications.position = newValue;
+                }
+                options: [
+                    {
+                        displayName: Translation.tr("Top left"),
+                        icon: "north_west",
+                        value: "top_left"
+                    },
+                    {
+                        displayName: Translation.tr("Top right"),
+                        icon: "north_east",
+                        value: "top_right"
+                    },
+                    {
+                        displayName: Translation.tr("Bottom left"),
+                        icon: "south_west",
+                        value: "bottom_left"
+                    },
+                    {
+                        displayName: Translation.tr("Bottom right"),
+                        icon: "south_east",
+                        value: "bottom_right"
+                    }
+                ]
+            }
+        }
+
+        ContentSubsection {
             title: Translation.tr("Privacy level")
             icon: "visibility"
             Layout.fillWidth: true

--- a/dots/.config/quickshell/ii/modules/settings/configs/LockScreenConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/LockScreenConfig.qml
@@ -172,6 +172,18 @@ ContentPage {
             }
         }
 
+        ConfigSpinBox {
+            icon: "zoom_in"
+            text: Translation.tr("Notification size (%)")
+            value: Config.options.lock.notifications.zoomPercent
+            from: 50
+            to: 200
+            stepSize: 10
+            onValueChanged: {
+                Config.options.lock.notifications.zoomPercent = value;
+            }
+        }
+
         ContentSubsection {
             title: Translation.tr("App rules")
             icon: "apps"

--- a/dots/.config/quickshell/ii/modules/settings/configs/OverlaysConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/OverlaysConfig.qml
@@ -34,6 +34,18 @@ Item {
                 }
             }
 
+            ConfigSpinBox {
+                icon: "zoom_in"
+                text: Translation.tr("Notification size (%)")
+                value: Config.options.notifications.zoomPercent
+                from: 50
+                to: 200
+                stepSize: 10
+                onValueChanged: {
+                    Config.options.notifications.zoomPercent = value;
+                }
+            }
+
             ConfigSwitch {
                 buttonIcon: "desktop_windows"
                 text: Translation.tr("Force specific monitor")


### PR DESCRIPTION
## Describe your changes

Added notifications to the ii lock screen. It's off by default (privacy trade-off — anyone standing at the machine can read them), toggleable from Settings → Lock Screen → Notifications.

<img width="2878" height="1798" alt="image" src="https://github.com/user-attachments/assets/ae62fc2d-82f7-4466-ba5f-0d2df8f5fcd9" />

- Pick how much gets shown: full content, just the app name + count, or a single count badge. Critical stuff like low-battery warnings can be set to always show in full regardless.
- Pick which corner it shows in. New notifications stack toward the screen edge — top corners stack downward from the top like you'd expect, bottom corners stack upward from the bottom instead of jumping to the top.
- Per-app control: set any app to always show, never show, or just follow the default. Search installed apps or type a name directly.
- A few extra filters: skip transient notifications, skip low-priority ones, only show what arrived after you locked, and cap how many show at once.

It's strictly read-only (as of now, but I can change that later if needed) — no dismissing, no replying, no acting on notifications + doesn't grab focus away from the password field.

Only the default (ii) lock screen for now (can be changed later too if needed) — Waffle's lock screen isn't touched.

## Is it ready? Questions/feedback needed?

Tested on my own machine: all four corners and stacking directions, all three privacy levels, the critical override, the filters, and per-app rules. Password field keeps focus fine with notifications showing.

Not tested: Multi-monitor lock setups.