### PR TITLE
fix(clipboard): refresh image preview when switching between images

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/CliphistImage.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/CliphistImage.qml
@@ -55,6 +55,12 @@ Rectangle {
         decodeImageProcess.running = true;
     }
 
+    onEntryChanged: {
+        root.source = "";
+        decodeImageProcess.running = false;
+        decodeImageProcess.running = true;
+    }
+
     Process {
         id: decodeImageProcess
         command: ["bash", "-c", `mkdir -p '${imageDecodePath}' && { [ -f '${imageDecodeFilePath}' ] || echo '${StringUtils.shellSingleQuoteEscape(root.entry)}' | ${Cliphist.cliphistBinary} decode > '${imageDecodeFilePath}'; }`]


### PR DESCRIPTION
## Describe your changes

Fixed image previews in the clipboard panel that were getting stuck. If I selected an image entry then jumped straight to another image, the preview box would resize to fit the new image but the actual picture shown didn't change — it stayed on whatever was selected before. Only way to force a refresh was to click a text clipboard entry first, then go back to an image.


## Is it ready? Questions/feedback needed?

Ready.