### PR TITLE
Feat/oled saver

### DIFF
--- a/dots/.config/quickshell/ii/GlobalStates.qml
+++ b/dots/.config/quickshell/ii/GlobalStates.qml
@@ -19,6 +19,9 @@ Singleton {
     property bool crosshairOpen: false
     property bool mediaControlsOpen: false
     property bool mediaControlsPinned: false
+    // Names of screens currently blacked out by the OLED saver overlay. Independent
+    // per monitor: toggling one monitor doesn't affect the others.
+    property var oledSaverMonitors: []
     property bool osdBrightnessOpen: false
     property bool osdVolumeOpen: false
     property bool oskOpen: false

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -1202,6 +1202,11 @@ Singleton {
                 }
             }
 
+            property JsonObject oledSaver: JsonObject {
+                property int cursorHideDelay: 5 // seconds of no mouse movement before the cursor hides again
+                property int hintExtraDelay: 10 // extra seconds the dismiss hint stays visible after the cursor hides
+            }
+
             property JsonObject osd: JsonObject {
                 property int timeout: 2500
             }

--- a/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
@@ -59,7 +59,7 @@ Scope {
             required property var modelData
             screen: modelData
             
-            visible: !GlobalStates.screenLocked && !positionChanging 
+            visible: !GlobalStates.screenLocked && !positionChanging && !GlobalStates.oledSaverMonitors.includes(modelData.name)
             // using a flag for positionChanging is not really necessary, but it prevents some graphical issues caused by qml when the dock is moving
 
             readonly property real availableW: screen?.width ?? 1920

--- a/dots/.config/quickshell/ii/modules/ii/oledSaver/OledSaver.qml
+++ b/dots/.config/quickshell/ii/modules/ii/oledSaver/OledSaver.qml
@@ -1,0 +1,151 @@
+pragma ComponentBehavior: Bound
+import qs
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import Quickshell.Wayland
+import Quickshell.Hyprland
+
+Scope {
+    id: root
+
+    // Names of screens currently blacked out. Independent per monitor:
+    // toggling affects only Hyprland's currently focused monitor.
+    property var activeMonitors: []
+
+    function toggle() {
+        const name = Hyprland.focusedMonitor?.name;
+        if (!name) return;
+        root.activeMonitors = root.activeMonitors.includes(name) ? root.activeMonitors.filter(n => n !== name) : [...root.activeMonitors, name];
+    }
+
+    function close(name) {
+        root.activeMonitors = root.activeMonitors.filter(n => n !== name);
+    }
+
+    // Inhibits sleep/lock/DPMS while at least one monitor is blacked out.
+    // Kept independent from the shared Idle.inhibit toggle so this feature
+    // never clobbers the user's own manual idle-inhibit preference.
+    IdleInhibitor {
+        enabled: root.activeMonitors.length > 0
+        window: PanelWindow {
+            implicitWidth: 0
+            implicitHeight: 0
+            color: "transparent"
+            anchors {
+                right: true
+                bottom: true
+            }
+            mask: Region {
+                item: null
+            }
+        }
+    }
+
+    IpcHandler {
+        target: "oledSaver"
+
+        function toggle() {
+            root.toggle();
+        }
+    }
+
+    GlobalShortcut {
+        name: "oledSaverToggle"
+        description: "Toggles the OLED saver (blackout) on the focused monitor"
+        onPressed: root.toggle()
+    }
+
+    component OledSaverWindow: PanelWindow {
+        id: window
+        signal dismiss
+
+        color: "black"
+        WlrLayershell.namespace: "quickshell:oledSaver"
+        // Top (not Overlay) so OSD, notifications, polkit prompts, etc. still
+        // render above the blackout instead of being hidden by it.
+        WlrLayershell.layer: WlrLayer.Top
+        WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+        exclusionMode: ExclusionMode.Ignore
+        anchors {
+            top: true
+            bottom: true
+            left: true
+            right: true
+        }
+
+        property bool cursorVisible: false
+        property bool hintVisible: false
+
+        Item {
+            anchors.fill: parent
+            focus: true
+
+            Keys.onPressed: event => {
+                if (event.key === Qt.Key_Escape)
+                    window.dismiss();
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: window.cursorVisible ? Qt.ArrowCursor : Qt.BlankCursor
+
+                onPositionChanged: {
+                    window.cursorVisible = true;
+                    window.hintVisible = true;
+                    cursorHideTimer.restart();
+                    hintHideTimer.restart();
+                }
+                onClicked: window.dismiss()
+            }
+
+            StyledText {
+                anchors.centerIn: parent
+                text: Translation.tr("Press Esc or click to exit")
+                color: "white"
+                font.pixelSize: Appearance.font.pixelSize.large
+                opacity: window.hintVisible ? 1 : 0
+                visible: opacity > 0
+
+                Behavior on opacity {
+                    NumberAnimation {
+                        duration: Appearance.animation.elementMoveFast.duration
+                        easing.type: Appearance.animation.elementMoveFast.type
+                        easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                    }
+                }
+            }
+
+            Timer {
+                id: cursorHideTimer
+                interval: Config.options.oledSaver.cursorHideDelay * 1000
+                onTriggered: window.cursorVisible = false
+            }
+
+            Timer {
+                id: hintHideTimer
+                interval: (Config.options.oledSaver.cursorHideDelay + Config.options.oledSaver.hintExtraDelay) * 1000
+                onTriggered: window.hintVisible = false
+            }
+        }
+    }
+
+    Variants {
+        model: Quickshell.screens
+
+        delegate: Loader {
+            id: oledSaverLoader
+            required property var modelData
+            active: root.activeMonitors.includes(modelData.name)
+
+            sourceComponent: OledSaverWindow {
+                screen: oledSaverLoader.modelData
+                onDismiss: root.close(oledSaverLoader.modelData.name)
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/oledSaver/OledSaver.qml
+++ b/dots/.config/quickshell/ii/modules/ii/oledSaver/OledSaver.qml
@@ -12,25 +12,22 @@ import Quickshell.Hyprland
 Scope {
     id: root
 
-    // Names of screens currently blacked out. Independent per monitor:
-    // toggling affects only Hyprland's currently focused monitor.
-    property var activeMonitors: []
-
     function toggle() {
         const name = Hyprland.focusedMonitor?.name;
         if (!name) return;
-        root.activeMonitors = root.activeMonitors.includes(name) ? root.activeMonitors.filter(n => n !== name) : [...root.activeMonitors, name];
+        const monitors = GlobalStates.oledSaverMonitors;
+        GlobalStates.oledSaverMonitors = monitors.includes(name) ? monitors.filter(n => n !== name) : [...monitors, name];
     }
 
     function close(name) {
-        root.activeMonitors = root.activeMonitors.filter(n => n !== name);
+        GlobalStates.oledSaverMonitors = GlobalStates.oledSaverMonitors.filter(n => n !== name);
     }
 
     // Inhibits sleep/lock/DPMS while at least one monitor is blacked out.
     // Kept independent from the shared Idle.inhibit toggle so this feature
     // never clobbers the user's own manual idle-inhibit preference.
     IdleInhibitor {
-        enabled: root.activeMonitors.length > 0
+        enabled: GlobalStates.oledSaverMonitors.length > 0
         window: PanelWindow {
             implicitWidth: 0
             implicitHeight: 0
@@ -140,7 +137,7 @@ Scope {
         delegate: Loader {
             id: oledSaverLoader
             required property var modelData
-            active: root.activeMonitors.includes(modelData.name)
+            active: GlobalStates.oledSaverMonitors.includes(modelData.name)
 
             sourceComponent: OledSaverWindow {
                 screen: oledSaverLoader.modelData

--- a/dots/.config/quickshell/ii/modules/settings/configs/CoreServicesConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/CoreServicesConfig.qml
@@ -108,6 +108,15 @@ Item {
                     description: qsTr("User agent and resource polling")
                     onOpenCard: root.openSubPage("widgets/CoreNetworkConfig.qml")
                 }
+
+                ServiceCard {
+                    cardIcon: "brightness_1"
+                    cardHue: 12
+                    cardShape: "Cookie12Sided"
+                    title: qsTr("OLED Saver")
+                    description: qsTr("Blackout overlay timing")
+                    onOpenCard: root.openSubPage("widgets/CoreOledSaverConfig.qml")
+                }
             }
 
             Item {

--- a/dots/.config/quickshell/ii/modules/settings/configs/widgets/CoreOledSaverConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/widgets/CoreOledSaverConfig.qml
@@ -1,0 +1,91 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import Quickshell
+import Quickshell.Io
+import qs.services
+import qs.modules.common
+import qs.modules.common.functions
+import qs.modules.common.widgets
+
+ContentPage {
+    id: root
+    forceWidth: false
+    signal goBack()
+
+    RowLayout {
+        spacing: 12
+
+        RippleButton {
+            implicitWidth: implicitHeight
+            implicitHeight: 40
+            topLeftRadius: Appearance.rounding.full
+            topRightRadius: Appearance.rounding.full
+            bottomLeftRadius: Appearance.rounding.full
+            bottomRightRadius: Appearance.rounding.full
+            colBackground: Appearance.colors.colSecondaryContainer
+            colBackgroundHover: Appearance.colors.colSecondaryContainerHover
+            colRipple: Appearance.colors.colSecondaryContainerActive
+
+            MaterialSymbol {
+                anchors.centerIn: parent
+                text: "arrow_back"
+                iconSize: Appearance.font.pixelSize.large
+                color: Appearance.colors.colOnSecondaryContainer
+            }
+
+            onClicked: root.goBack()
+        }
+
+        StyledText {
+            text: Translation.tr("OLED Saver")
+            font.pixelSize: Appearance.font.pixelSize.large
+            font.family: Appearance.font.family.title
+            color: Appearance.colors.colOnLayer0
+        }
+    }
+    ContentSection {
+        icon: "brightness_1"
+        title: Translation.tr("Blackout timing")
+
+        StyledText {
+            text: Translation.tr("Super + R blacks out the focused monitor. Esc, click, or the same shortcut dismisses it.")
+            color: Appearance.colors.colOnLayer1
+            opacity: 0.75
+            font.pixelSize: Appearance.font.pixelSize.small
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            Layout.bottomMargin: 8
+        }
+
+        ConfigSpinBox {
+            icon: "mouse"
+            text: Translation.tr("Cursor hide delay (seconds)")
+            value: Config.options.oledSaver.cursorHideDelay
+            from: 1
+            to: 60
+            stepSize: 1
+            onValueChanged: {
+                Config.options.oledSaver.cursorHideDelay = value;
+            }
+            StyledToolTip {
+                text: Translation.tr("How long after you stop moving the mouse before the cursor hides again")
+            }
+        }
+
+        ConfigSpinBox {
+            icon: "help"
+            text: Translation.tr("Extra hint duration (seconds)")
+            value: Config.options.oledSaver.hintExtraDelay
+            from: 0
+            to: 60
+            stepSize: 1
+            onValueChanged: {
+                Config.options.oledSaver.hintExtraDelay = value;
+            }
+            StyledToolTip {
+                text: Translation.tr("How much longer the \"Esc or click to exit\" hint stays up after the cursor hides")
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/panelFamilies/IllogicalImpulseFamily.qml
+++ b/dots/.config/quickshell/ii/panelFamilies/IllogicalImpulseFamily.qml
@@ -13,6 +13,7 @@ import qs.modules.ii.mediaControls
 import qs.modules.ii.notificationPopup
 import qs.modules.ii.onScreenDisplay
 import qs.modules.ii.onScreenKeyboard
+import qs.modules.ii.oledSaver
 import qs.modules.ii.overview
 import qs.modules.ii.polkit
 import qs.modules.ii.regionSelector
@@ -94,6 +95,9 @@ Scope {
     }
     PanelLoader {
         component: OnScreenKeyboard {}
+    }
+    PanelLoader {
+        component: OledSaver {}
     }
     PanelLoader {
         component: Overlay {}

--- a/dots/.config/quickshell/ii/panelFamilies/WaffleFamily.qml
+++ b/dots/.config/quickshell/ii/panelFamilies/WaffleFamily.qml
@@ -18,6 +18,7 @@ import qs.modules.waffle.taskView
 
 // Fallbacks
 import qs.modules.ii.cheatsheet
+import qs.modules.ii.oledSaver
 import qs.modules.ii.onScreenKeyboard
 import qs.modules.ii.overlay
 import qs.modules.ii.screenTranslator
@@ -39,6 +40,7 @@ Scope {
     PanelLoader { component: WaffleTaskView {} }
 
     PanelLoader { component: Cheatsheet {} }
+    PanelLoader { component: OledSaver {} }
     PanelLoader { component: OnScreenKeyboard {} }
     PanelLoader { component: Overlay {} }
     PanelLoader { component: ScreenTranslator {} }


### PR DESCRIPTION
## Describe your changes

Added a black overlay that inhibits sleep too. A screen saver for OLED displays. 

Keybind to add to hyprland config:
```
-- Toggle OLED saver (blackout overlay on the focused monitor)
hl.bind("SUPER + R", hl.dsp.global("quickshell:oledSaverToggle"),
    { locked = true, description = "Utilities: Toggle OLED saver (blackout)" })
```

## Is it ready? Questions/feedback needed?

I intentionally left some transient overlays visible on top, like OSD for brightness sound and keyboard backlight, and notifications. While I haven't seen any bugs other than the dock (fixed) there may be more edge case I haven't thought about

I haven't tested multi monitors setups but it should be handled fine (each monitor is treated as a different entity and therefore each monitor can have independently the overlay active or not)