### PR TITLE
fix(battery): show percentage in classic and expressive layouts

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -1062,6 +1062,7 @@ Singleton {
                     property bool showSecondary: true
                     property bool swapPrimaryWithSecondary: false
                     property bool showPercentageInsideBattery: false
+                    property string showPercentage: "off"
                 }
                 property string bluetoothDevicesLayout: "expressive" // Options: classic, expressive
                 property JsonObject sizes: JsonObject {


### PR DESCRIPTION
## Describe your changes

Fixed the battery percentage not showing up for windows 11 battery style.
Probably due to my old PR on the battery charge limit

## Is it ready? Questions/feedback needed?

Ready