### PR TITLE
feat(lock): show remaining fingerprint tries and failure feedback

### DIFF
--- a/dots/.config/hypr/hypridle.conf
+++ b/dots/.config/hypr/hypridle.conf
@@ -4,7 +4,10 @@ $suspend_cmd = systemctl suspend || loginctl suspend
 
 general {
     lock_cmd = $lock_cmd
-    before_sleep_cmd = loginctl lock-session
+    # Lock, then stop the lockscreen's fingerprint prompt before suspending:
+    # some fingerprint drivers (e.g. egismoc) crash fprintd if the system
+    # sleeps with a verify in flight. after_sleep_cmd restarts the prompt.
+    before_sleep_cmd = loginctl lock-session && sleep 0.5 && hyprctl dispatch 'hl.dsp.global("quickshell:lockFingerStop")'
     after_sleep_cmd = hyprctl dispatch 'hl.dsp.global("quickshell:lockFocus")'
     inhibit_sleep = 3
 }

--- a/dots/.config/quickshell/ii/modules/common/panels/lock/LockContext.qml
+++ b/dots/.config/quickshell/ii/modules/common/panels/lock/LockContext.qml
@@ -20,6 +20,10 @@ Scope {
     property bool unlockInProgress: false
     property bool showFailure: false
     property bool fingerprintsConfigured: false
+    // pam_fprintd default max-tries is 3 (pam/fprintd.conf passes no override)
+    readonly property int fingerprintMaxTries: 3
+    property int fingerprintTriesLeft: fingerprintMaxTries
+    signal fingerprintFailed()
     property var targetAction: LockContext.ActionEnum.Unlock
     property bool alsoInhibitIdle: false
 
@@ -67,6 +71,9 @@ Scope {
 
     function tryFingerUnlock() {
         if (root.fingerprintsConfigured) {
+            // Each start() is a fresh PAM transaction, so pam_fprintd's
+            // internal try counter resets too.
+            root.fingerprintTriesLeft = root.fingerprintMaxTries;
             fingerPam.start();
         }
     }
@@ -124,6 +131,15 @@ Scope {
 
         configDirectory: "pam"
         config: "fprintd.conf"
+
+        // pam_fprintd sends an error-type conversation message per failed
+        // scan; timeouts ("Verification timed out") must not count as tries.
+        onPamMessage: {
+            if (this.messageIsError && this.message.includes("Failed to match")) {
+                root.fingerprintTriesLeft = Math.max(0, root.fingerprintTriesLeft - 1);
+                root.fingerprintFailed();
+            }
+        }
 
         onCompleted: result => {
             if (result == PamResult.Success) {

--- a/dots/.config/quickshell/ii/modules/common/panels/lock/LockContext.qml
+++ b/dots/.config/quickshell/ii/modules/common/panels/lock/LockContext.qml
@@ -78,6 +78,30 @@ Scope {
         }
     }
 
+    // The refocus signal also fires from hypridle's after_sleep_cmd. A verify
+    // that was in flight across suspend is dead (some readers even crash
+    // fprintd), so trade it for a fresh transaction. No-op when unlocked or
+    // without fingerprints.
+    onShouldReFocus: restartFingerUnlock()
+
+    function restartFingerUnlock() {
+        if (!root.fingerprintsConfigured || !GlobalStates.screenLocked)
+            return;
+        stopFingerPam();
+        fingerRestartTimer.restart();
+    }
+
+    Timer {
+        id: fingerRestartTimer
+        // Long enough for the aborted transaction to end and a crashed
+        // fprintd to be restarted by systemd
+        interval: 1000
+        onTriggered: {
+            if (GlobalStates.screenLocked)
+                root.tryFingerUnlock();
+        }
+    }
+
     function stopFingerPam() {
         if (fingerPam.active) {
             fingerPam.abort();

--- a/dots/.config/quickshell/ii/modules/common/panels/lock/LockScreen.qml
+++ b/dots/.config/quickshell/ii/modules/common/panels/lock/LockScreen.qml
@@ -129,6 +129,9 @@ Scope {
         function focus(): void {
             lockContext.shouldReFocus();
         }
+        function fingerStop(): void {
+            lockContext.stopFingerPam();
+        }
     }
 
     GlobalShortcut {
@@ -137,6 +140,15 @@ Scope {
 
         onPressed: {
             root.lock();
+        }
+    }
+
+    GlobalShortcut {
+        name: "lockFingerStop"
+        description: "Stops the lock screen's fingerprint prompt. Meant for hypridle's before_sleep_cmd:" + " suspending with a fingerprint operation in flight crashes some readers' drivers"
+
+        onPressed: {
+            lockContext.stopFingerPam();
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/lock/LockSurface.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/LockSurface.qml
@@ -189,12 +189,78 @@ MouseArea {
             active: root.context.fingerprintsConfigured
             visible: active
 
-            sourceComponent: MaterialSymbol {
-                id: fingerprintIcon
-                fill: 1
-                text: "fingerprint"
-                iconSize: Appearance.font.pixelSize.hugeass
-                color: Appearance.colors.colOnSurfaceVariant
+            sourceComponent: ColumnLayout {
+                id: fingerprintStatus
+                spacing: 0
+
+                readonly property int triesLeft: root.context.fingerprintTriesLeft
+                readonly property bool exhausted: triesLeft === 0
+                property bool failureFlash: false
+
+                Connections {
+                    target: root.context
+                    function onFingerprintFailed() {
+                        fingerprintStatus.failureFlash = true;
+                        failureFlashTimer.restart();
+                        fingerprintShakeAnim.restart();
+                    }
+                }
+                Timer {
+                    id: failureFlashTimer
+                    interval: 800
+                    onTriggered: fingerprintStatus.failureFlash = false
+                }
+
+                MaterialSymbol {
+                    id: fingerprintIcon
+                    Layout.alignment: Qt.AlignHCenter
+                    fill: 1
+                    text: "fingerprint"
+                    iconSize: Appearance.font.pixelSize.hugeass
+                    color: (fingerprintStatus.failureFlash || fingerprintStatus.exhausted)
+                        ? Appearance.colors.colError
+                        : Appearance.colors.colOnSurfaceVariant
+                    opacity: fingerprintStatus.exhausted ? 0.5 : 1
+                    Behavior on color {
+                        ColorAnimation { duration: 200 }
+                    }
+                    Behavior on opacity {
+                        NumberAnimation { duration: 200 }
+                    }
+
+                    transform: Translate { id: fingerprintShakeOffset }
+                    SequentialAnimation {
+                        id: fingerprintShakeAnim
+                        NumberAnimation { target: fingerprintShakeOffset; property: "x"; to: -6; duration: 50 }
+                        NumberAnimation { target: fingerprintShakeOffset; property: "x"; to: 6; duration: 50 }
+                        NumberAnimation { target: fingerprintShakeOffset; property: "x"; to: -3; duration: 40 }
+                        NumberAnimation { target: fingerprintShakeOffset; property: "x"; to: 3; duration: 40 }
+                        NumberAnimation { target: fingerprintShakeOffset; property: "x"; to: 0; duration: 30 }
+                    }
+                }
+
+                RowLayout {
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 4
+                    Repeater {
+                        model: root.context.fingerprintMaxTries
+                        Rectangle {
+                            implicitWidth: 5
+                            implicitHeight: 5
+                            radius: 2.5
+                            color: index < fingerprintStatus.triesLeft
+                                ? ((fingerprintStatus.failureFlash) ? Appearance.colors.colError : Appearance.colors.colOnSurfaceVariant)
+                                : "transparent"
+                            border.width: index < fingerprintStatus.triesLeft ? 0 : 1
+                            border.color: fingerprintStatus.exhausted
+                                ? Appearance.colors.colError
+                                : Appearance.colors.colOutline
+                            Behavior on color {
+                                ColorAnimation { duration: 200 }
+                            }
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Describe your changes

Added number of tries left indicator on the lockscreen for fingerprint reader (I had no idea this even existed before I finally managed to make mine work), plus a color shift (red) + shake on error.
Also since PAM resets, I also made the tries counter follows dynamically how much tries left there is



https://github.com/user-attachments/assets/a4f1e656-2dd0-4088-8fbc-865e332f97e5

(You can skip from 0:08 to 0:28)

**Second commit — fingerprint vs suspend:**

While testing this I found that closing the lid while the fingerprint prompt is running crashes fprintd on my laptop (the egismoc driver core-dumps if the system sleeps mid-verify). Result: on the first lock after waking the sensor is just dead until you unlock with your password once.

So the lockscreen now stops the fingerprint prompt right before sleeping and restarts it after waking:
- New global shortcut `quickshell:lockFingerStop` (+ `lock fingerStop` IPC), called from hypridle's `before_sleep_cmd`
- The restart on wake piggybacks on the `lockFocus` dispatch that was already in `after_sleep_cmd`
- The dots refill on restart, which is correct since it's a fresh PAM transaction

One thing to flag clearly: `before_sleep_cmd` now has a `sleep 0.5` in it (so the stop lands after the lockscreen has started the prompt) — that delays suspend by ~0.5s for everyone, fingerprint or not.

Also worth knowing:
- Waffle's lock reuses the shared LockScreen so it gets the suspend fix too; the dots/shake visuals are ii-only
- hyprlock setups are unaffected (the dispatch is a no-op there)
- People with a hand-edited hypridle.conf won't pick up the new line automatically

## Is it ready? Questions/feedback needed?

Works on my laptop perfectly
One thing I'd like feedback on: failed scans are detected by matching pam_fprintd's English "Failed to match fingerprint" message text, since PAM doesn't expose the failure any other way mid-transaction. On non-English locales the counter won't decrement (dots just stay full — everything else still works, so it degrades gracefully).

For the second commit: tested the full lid close → sleep → wake cycle on my machine, the first lock after wake now takes fingerprints again. Not tested: the Waffle lock surface and hyprlock setups. Also the dots assume pam_fprintd's default max-tries=3 — if a distro patches that default the count would be off (cosmetic only).
