### PR TITLE
feat(workspaces): add keybind to compact workspaces into 1..N

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ __pycache__/
 /dots/.config/quickshell/ii/.active-fork
 /dots/.config/quickshell/ii/.cortexkit
 /dots/.config/quickshell/ii/user_widgets
+
+# Compiled binary — build it from workspace_compactor_src/ instead (see scripts/hyprland/README.md)
+/dots/.config/quickshell/ii/scripts/hyprland/workspace_compactor

--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -193,6 +193,10 @@ for i = 1, 6 do
     hl.bind(keycombos[i], hl.dsp.window.move({ workspace = prefix[i] .. "1" })) -- # [hidden]
 end
 
+--#/# bind = CTRL+SUPER, C,, -- Compact workspaces into 1..N (remove empty gaps)
+hl.bind("CTRL + SUPER + C", hl.dsp.exec_cmd(qsScripts .. "/hyprland/workspace_compactor"),
+    { description = "Workspaces: Compact into 1..N (remove empty gaps)" })
+
 hl.bind("SUPER + ALT + S", function()
     local ok, err = pcall(function()
         local w = hl.get_active_window()

--- a/dots/.config/quickshell/ii/scripts/hyprland/README.md
+++ b/dots/.config/quickshell/ii/scripts/hyprland/README.md
@@ -18,3 +18,42 @@ cd ~/.config/quickshell/ii/scripts/hyprland/workspace_profile_manager_src
 cargo build --release
 cp target/release/workspace_profile_manager ../
 ```
+
+## Workspace Compactor
+
+Renumbers the focused monitor's workspaces so the occupied ones run 1..N with no gaps — with
+apps on 2, 4 and 5, it pulls them down to 1, 2 and 3. Windows sharing a workspace stay together
+and keep their order, floating geometry is restored exactly, and tiled geometry is replayed
+best-effort so dwindle's split ratios land close to where they were. Special and named
+workspaces are left untouched. Bound to `CTRL + SUPER + C`.
+
+The active workspace follows its own contents to their new number. If it was left empty, focus
+falls back to the nearest occupied workspace below it.
+
+**Source:** `~/.config/quickshell/ii/scripts/hyprland/workspace_compactor_src/`
+
+### Building from Source
+
+Requires Rust/`cargo` ([install via rustup](https://rustup.rs)). The binary is not shipped — build
+it once and the keybind picks it up.
+
+```bash
+cd ~/.config/quickshell/ii/scripts/hyprland/workspace_compactor_src
+cargo build --release
+cp target/release/workspace_compactor ../
+```
+
+### Keybind
+
+In `~/.config/hypr/hyprland/keybinds.lua`:
+
+```lua
+local qsScripts = "$HOME/.config/quickshell/$qsConfig/scripts"
+
+--#/# bind = CTRL+SUPER, C,, -- Compact workspaces into 1..N (remove empty gaps)
+hl.bind("CTRL + SUPER + C", hl.dsp.exec_cmd(qsScripts .. "/hyprland/workspace_compactor"),
+    { description = "Workspaces: Compact into 1..N (remove empty gaps)" })
+```
+
+`qsScripts` is already declared at the top of that file — you only need that line if you put the
+bind somewhere else, like `~/.config/hypr/custom/keybinds.lua`.

--- a/dots/.config/quickshell/ii/scripts/hyprland/workspace_compactor_src/.gitignore
+++ b/dots/.config/quickshell/ii/scripts/hyprland/workspace_compactor_src/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/dots/.config/quickshell/ii/scripts/hyprland/workspace_compactor_src/Cargo.toml
+++ b/dots/.config/quickshell/ii/scripts/hyprland/workspace_compactor_src/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "workspace_compactor"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde_json = "1.0.150"
+
+[profile.release]
+opt-level = "z"
+lto = true
+strip = true

--- a/dots/.config/quickshell/ii/scripts/hyprland/workspace_compactor_src/src/main.rs
+++ b/dots/.config/quickshell/ii/scripts/hyprland/workspace_compactor_src/src/main.rs
@@ -1,0 +1,208 @@
+// Compacts the focused monitor's workspaces so occupied ones become 1..N with no gaps.
+//
+// Windows on a workspace stay together and keep their order; floating geometry is restored
+// exactly, tiled geometry is replayed best-effort to nudge dwindle's split ratios back.
+// Special and named workspaces are left alone.
+
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+
+/// Speaks the Hyprland IPC protocol directly — no `hyprctl` subprocess.
+fn hyprctl(command: &str) -> Option<String> {
+    let xdg_runtime = env::var("XDG_RUNTIME_DIR").ok()?;
+    let sig = env::var("HYPRLAND_INSTANCE_SIGNATURE").ok()?;
+    let path = format!("{}/hypr/{}/.socket.sock", xdg_runtime, sig);
+
+    let mut stream = UnixStream::connect(&path).ok()?;
+    stream.write_all(command.as_bytes()).ok()?;
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).ok()?;
+    Some(response)
+}
+
+fn query(what: &str) -> Option<Value> {
+    serde_json::from_str(&hyprctl(&format!("j/{}", what))?).ok()
+}
+
+/// This Hyprland evaluates `dispatch` payloads as Lua, so dispatchers use the `hl.dsp.*` form.
+fn dispatch_batch(cmds: &[String]) {
+    if cmds.is_empty() {
+        return;
+    }
+    let joined = cmds
+        .iter()
+        .map(|c| format!("dispatch {}", c))
+        .collect::<Vec<_>>()
+        .join(";");
+    hyprctl(&format!("[[BATCH]]{}", joined));
+}
+
+struct Snap {
+    address: String,
+    ws_id: i64,
+    at: (i64, i64),
+    size: (i64, i64),
+    floating: bool,
+    fullscreen: bool,
+    group: Vec<String>,
+}
+
+fn pair(v: &Value, key: &str) -> Option<(i64, i64)> {
+    let a = v.get(key)?.as_array()?;
+    Some((a.first()?.as_i64()?, a.get(1)?.as_i64()?))
+}
+
+/// Regular numbered workspaces only: special ones carry a negative id, named ones a
+/// non-numeric name.
+fn is_regular(ws: &Value) -> bool {
+    let id = ws.get("id").and_then(|v| v.as_i64()).unwrap_or(0);
+    let name = ws.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    id > 0 && name == id.to_string()
+}
+
+fn snapshot(mon_id: i64) -> Vec<Snap> {
+    let Some(clients) = query("clients") else {
+        return Vec::new();
+    };
+    let Some(arr) = clients.as_array() else {
+        return Vec::new();
+    };
+
+    // Preserves hyprctl's own ordering, the closest proxy we have to dwindle's insertion order.
+    arr.iter()
+        .filter(|c| c.get("monitor").and_then(|v| v.as_i64()) == Some(mon_id))
+        .filter(|c| c.get("workspace").map(is_regular).unwrap_or(false))
+        .filter_map(|c| {
+            Some(Snap {
+                address: c.get("address")?.as_str()?.to_string(),
+                ws_id: c.get("workspace")?.get("id")?.as_i64()?,
+                at: pair(c, "at")?,
+                size: pair(c, "size")?,
+                floating: c.get("floating").and_then(|v| v.as_bool()).unwrap_or(false),
+                fullscreen: c.get("fullscreen").and_then(|v| v.as_i64()).unwrap_or(0) != 0,
+                group: c
+                    .get("grouped")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.iter().filter_map(|g| g.as_str().map(String::from)).collect())
+                    .unwrap_or_default(),
+            })
+        })
+        .collect()
+}
+
+fn main() {
+    let Some(monitors) = query("monitors") else {
+        eprintln!("workspace_compactor: cannot reach the Hyprland socket");
+        std::process::exit(1);
+    };
+    let Some(focused) = monitors
+        .as_array()
+        .and_then(|a| a.iter().find(|m| m.get("focused").and_then(|v| v.as_bool()) == Some(true)))
+    else {
+        eprintln!("workspace_compactor: no focused monitor");
+        std::process::exit(1);
+    };
+
+    let mon_id = focused.get("id").and_then(|v| v.as_i64()).unwrap_or(0);
+    let active_ws = focused
+        .get("activeWorkspace")
+        .and_then(|w| w.get("id"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(1);
+
+    let snaps = snapshot(mon_id);
+    if snaps.is_empty() {
+        return;
+    }
+
+    let mut occupied: Vec<i64> = snaps.iter().map(|s| s.ws_id).collect();
+    occupied.sort_unstable();
+    occupied.dedup();
+
+    let mapping: HashMap<i64, i64> = occupied
+        .iter()
+        .enumerate()
+        .map(|(rank, &ws)| (ws, rank as i64 + 1))
+        .collect();
+
+    if mapping.iter().all(|(src, dst)| src == dst) {
+        return; // already gapless
+    }
+
+    // Remember what to re-focus before anything moves. This can name a window on a workspace
+    // we aren't even looking at: a silent move leaves focus attached to the window it sent away.
+    let focused_window = query("activewindow")
+        .and_then(|w| w.get("address").and_then(|v| v.as_str()).map(String::from));
+
+    // Ascending source order means every target is either originally empty or already
+    // vacated by an earlier move, so sources never collide with each other.
+    let mut moves = Vec::new();
+    let mut handled: HashSet<&str> = HashSet::new();
+    for src in &occupied {
+        let dst = mapping[src];
+        if dst == *src {
+            continue;
+        }
+        for s in snaps.iter().filter(|s| s.ws_id == *src) {
+            if handled.contains(s.address.as_str()) {
+                continue;
+            }
+            // Moving any member of a group drags the whole group along.
+            handled.insert(&s.address);
+            handled.extend(s.group.iter().map(String::as_str));
+
+            moves.push(format!(
+                "hl.dsp.window.move({{ workspace = {}, window = \"address:{}\", follow = false }})",
+                dst, s.address
+            ));
+        }
+    }
+    dispatch_batch(&moves);
+
+    // Replay geometry only for windows that actually moved. Fullscreen windows keep their
+    // state across the move on their own and must not be resized.
+    let mut geometry = Vec::new();
+    for s in &snaps {
+        if s.fullscreen || mapping[&s.ws_id] == s.ws_id {
+            continue;
+        }
+        geometry.push(format!(
+            "hl.dsp.window.resize({{ x = {}, y = {}, relative = false, window = \"address:{}\" }})",
+            s.size.0, s.size.1, s.address
+        ));
+        if s.floating {
+            geometry.push(format!(
+                "hl.dsp.window.move({{ x = {}, y = {}, relative = false, window = \"address:{}\" }})",
+                s.at.0, s.at.1, s.address
+            ));
+        }
+    }
+    dispatch_batch(&geometry);
+
+    // Follow the active workspace to its new number. If it was empty it has no mapping, so
+    // fall back to the nearest occupied workspace below it; failing that, stay put.
+    let target_ws = mapping.get(&active_ws).copied().unwrap_or_else(|| {
+        occupied
+            .iter()
+            .filter(|&&ws| ws < active_ws)
+            .max()
+            .map(|ws| mapping[ws])
+            .unwrap_or(active_ws)
+    });
+
+    // Restoring the remembered window is only right when it landed on the workspace we're
+    // switching to. Otherwise focus is stale and re-applying it would drag the view off to
+    // wherever that window went, overriding the choice made just above.
+    let refocus = focused_window
+        .filter(|addr| snaps.iter().any(|s| &s.address == addr && mapping[&s.ws_id] == target_ws));
+
+    let mut focus = vec![format!("hl.dsp.focus({{ workspace = {} }})", target_ws)];
+    if let Some(addr) = refocus {
+        focus.push(format!("hl.dsp.focus({{ window = \"address:{}\" }})", addr));
+    }
+    dispatch_batch(&focus);
+}


### PR DESCRIPTION
## Describe your changes

Emptying a workspace always left a hole behind — Windows on workspace 2, 4 and 5, nothing in between. The only fix was dragging every window across by hand (from the overview, or using keybinds)—not really user friendly.

CTRL + SUPER + C now pulls them back down: apps on 2, 4 and 5 become 1, 2 and 3.

- Windows sharing a workspace stay together and keep their arrangement — floating ones don't budge, tiled ones come back close to how you had them.
- Your current workspace (what is you view) follows what you were looking at to its new number. If you'd just emptied the workspace you were on, you land on the nearest one below it.
- Scratchpad and named workspaces are left alone, and pressing it when there's nothing to close up does nothing.

Only the focused monitor is touched. It's a small Rust helper, same as the workspace profile manager — I didn't commit the binary, so it needs building once (instructions in the scripts README).

## Is it ready? Questions/feedback needed?

Works and I've been using it, but a few gaps worth your eyes:

- Multi-monitor is untested. The per-monitor handling is written but has never actually run on 2+ monitors. Also: should it compact every monitor at once instead of just the focused one? Wasn't sure what would be expected so I only made it affect the current monitor.
- Only tried on dwindle. Tiled windows come back close but not pixel-perfect if you've hand-resized a deep split — floating ones are exact. And lots of windows in a single workspace can cause some issues with proper resizing (best-effort)


Also, should the rust build be included in the setup and update script? Since unlike the workspace_manager there is no GUI for this (it doesn't live on the cheatsheet)