### PR TITLE
fix(lock): reduce delay before windows return after unlock

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -1216,6 +1216,7 @@ Singleton {
                 property real centerSpacing: 20 // spacing between multiple centered widgets
                 property string centerAlignment: "horizontal" // "vertical" | "horizontal"
                 property bool showLockedText: true
+                property int windowRestoreDelay: 100 // ms, delay before workspaces slide back in after unlock; 0-2000, step 10
                 property JsonObject security: JsonObject {
                     property bool unlockKeyring: true
                     property bool requirePasswordToPower: false

--- a/dots/.config/quickshell/ii/modules/ii/lock/Lock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/Lock.qml
@@ -16,7 +16,7 @@ LockScreen {
 
     Timer {
         id: restoreTimer
-        interval: 700
+        interval: 100
         repeat: false
         onTriggered: {
             var batch = ""

--- a/dots/.config/quickshell/ii/modules/ii/lock/Lock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/lock/Lock.qml
@@ -16,7 +16,7 @@ LockScreen {
 
     Timer {
         id: restoreTimer
-        interval: 100
+        interval: Config.options.lock.windowRestoreDelay
         repeat: false
         onTriggered: {
             var batch = ""

--- a/dots/.config/quickshell/ii/modules/settings/configs/LockScreenConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/LockScreenConfig.qml
@@ -47,6 +47,23 @@ ContentPage {
             targetSectionTitle: Translation.tr("Parallax Engine")
             materialIcon: "loupe"
         }
+
+        ConfigSlider {
+            buttonIcon: "hourglass_bottom"
+            text: Translation.tr("Window restore delay")
+            value: Config.options.lock.windowRestoreDelay
+            from: 0
+            to: 2000
+            stepSize: 10
+            usePercentTooltip: false
+            tooltipContent: `${Math.round(value)}ms`
+            onValueChanged: {
+                Config.options.lock.windowRestoreDelay = value;
+            }
+            StyledToolTip {
+                text: Translation.tr("Delay before windows slide back in after unlocking. Lower feels snappier but may race the unlock animation.")
+            }
+        }
     }
 
     ContentSection {


### PR DESCRIPTION
## Describe your changes

Fixed an enormous delay between the unlock and the animation of sliding the windows back in. Was feeling really sluggish.

## Is it ready? Questions/feedback needed?

Should be ready but interval was tuned for my laptop. Unsure if smoothness feels the same on different (both more powerful and more limited hardware) hardware



Edit for the second commit:
Made the delay configurable (0ms up to 2000ms with 10ms step) with a slider under Lockscreen --> General
That resolves two issues:
- Perfect smoothness for all hardware and user preferences
- Fixes some weird thing with the ripple animation when unlocking (ripple animation increases the unlock animation so 100ms was way too short for this)