### PR TITLE
fix(notifications): stop right sidebar notifications overlapping

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/NotificationListView.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/NotificationListView.qml
@@ -15,6 +15,10 @@ StyledListView { // Scrollable window
     readonly property real zoom: popup ? (Config.options.notifications.zoomPercent / 100) : 1.0
     dismissToLeft: popup && (Config.options.notifications.position ?? "top_right").endsWith("left")
     useSlideInAnimation: popup
+    // Groups reorder by latest activity (Notifications.appNameList), and reused delegates
+    // leak per-item UI state (expanded, lazyLimit, implicitHeight animation) across
+    // different notification groups, causing stuck height/overlap glitches.
+    reuseItems: false
 
     spacing: 3
 


### PR DESCRIPTION
## Describe your changes

Fixed right sidebar notification overlapping eachother when several entries (under the same app) were present.

## Is it ready? Questions/feedback needed?

Ready