### PR TITLE
feat(phone): auto-detect scrcpy wireless IP and port

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -342,6 +342,7 @@ Singleton {
                     property int maxSize: 0
                     property int videoBuffer: 0  // scrcpy 4.0 default is 0ms — 80ms adds visible latency
                     property bool useWireless: false
+                    property bool autoWirelessIp: true  // resolve IP live from KDE Connect instead of the manual field
                     property string wirelessIp: ""
                     property string wirelessPort: "5555"
                     property bool showTerminal: false

--- a/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/phone/PhoneScrcpyPage.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/phone/PhoneScrcpyPage.qml
@@ -292,7 +292,9 @@ ContentPage {
                 }
                 onClicked: KdeConnectService.promptWirelessConnect(KdeConnectService.activeDeviceId)
                 StyledToolTip {
-                    text: Translation.tr("Prompt for IP:port and switch to wireless mode")
+                    text: Config.options.phone.scrcpy.autoWirelessIp
+                        ? Translation.tr("Connect wirelessly using the auto-detected IP")
+                        : Translation.tr("Prompt for IP:port and switch to wireless mode")
                 }
             }
 
@@ -444,7 +446,7 @@ ContentPage {
 
         StyledText {
             Layout.fillWidth: true
-            text: Translation.tr("1. Connect your phone via USB and allow ADB debugging.\n2. Enable TCP/IP mode.\n3. Disconnect USB and enter the phone's Wi-Fi IP below.")
+            text: Translation.tr("Auto-detect (recommended):\n1. On the phone, enable Developer options → Wireless debugging.\n2. Pair once with this PC if you never have.\n\nWith Auto-detect IP on, both the phone's address AND its wireless-debugging port — which Android randomises on every toggle/reboot — are discovered over the network (mDNS via avahi) on every launch. You never type either again.\n\nLegacy fallback: if your phone has no Wireless debugging, plug in USB, press \"Enable over USB\" (adb tcpip 5555), then unplug.")
             font.pixelSize: Appearance.font.pixelSize.small
             color: Appearance.colors.colSubtext
             wrapMode: Text.Wrap
@@ -534,8 +536,59 @@ ContentPage {
             onCheckedChanged: Config.options.phone.scrcpy.useWireless = checked
         }
 
+        ConfigSwitch {
+            visible: Config.options.phone.scrcpy.useWireless
+            buttonIcon: "sync_alt"
+            text: Translation.tr("Auto-detect IP (KDE Connect)")
+            checked: Config.options.phone.scrcpy.autoWirelessIp
+            onCheckedChanged: Config.options.phone.scrcpy.autoWirelessIp = checked
+        }
+
+        // Live readout of the target the next launch will use.
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: hostReadout.implicitHeight + 20
+            visible: Config.options.phone.scrcpy.useWireless
+                     && Config.options.phone.scrcpy.autoWirelessIp
+            radius: Appearance.rounding.small
+            color: KdeConnectService.resolvedWirelessHost !== ""
+                ? Appearance.colors.colPrimaryContainer
+                : Appearance.colors.colLayer2
+
+            RowLayout {
+                id: hostReadout
+                anchors.fill: parent
+                anchors.leftMargin: 12
+                anchors.rightMargin: 12
+                spacing: 8
+
+                MaterialSymbol {
+                    Layout.alignment: Qt.AlignVCenter
+                    text: KdeConnectService.resolvedWirelessHost !== "" ? "wifi_tethering" : "wifi_tethering_off"
+                    iconSize: 20
+                    color: KdeConnectService.resolvedWirelessHost !== ""
+                        ? Appearance.colors.colOnPrimaryContainer
+                        : Appearance.colors.colSubtext
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: KdeConnectService.resolvedWirelessHost !== ""
+                        ? Translation.tr("Will connect to %1").arg(KdeConnectService.resolvedWirelessHost)
+                        : Translation.tr("Waiting for KDE Connect to report the phone's IP…")
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    font.weight: Font.DemiBold
+                    color: KdeConnectService.resolvedWirelessHost !== ""
+                        ? Appearance.colors.colOnPrimaryContainer
+                        : Appearance.colors.colSubtext
+                    wrapMode: Text.Wrap
+                }
+            }
+        }
+
         ConfigTextField {
             visible: Config.options.phone.scrcpy.useWireless
+                     && !Config.options.phone.scrcpy.autoWirelessIp
             text: Translation.tr("Phone IP")
             icon: "ip"
             placeholderText: "192.168.1.42"
@@ -547,6 +600,7 @@ ContentPage {
 
         ConfigSpinBox {
             visible: Config.options.phone.scrcpy.useWireless
+                     && !Config.options.phone.scrcpy.autoWirelessIp
             text: Translation.tr("Port")
             icon: "router"
             value: Config.options.phone.scrcpy.wirelessPort

--- a/dots/.config/quickshell/ii/modules/settings/configs/DevicesPhoneConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/DevicesPhoneConfig.qml
@@ -40,6 +40,26 @@ ContentPage {
             }
         }
 
+        ConfigSwitch {
+            buttonIcon: "sync_alt"
+            text: Translation.tr("Auto-detect IP (KDE Connect)")
+            checked: Config.options.phone.scrcpy.autoWirelessIp
+            onCheckedChanged: {
+                Config.options.phone.scrcpy.autoWirelessIp = checked;
+            }
+            enabled: Config.options.phone.scrcpy.useWireless
+        }
+
+        StyledText {
+            Layout.fillWidth: true
+            Layout.leftMargin: 4
+            visible: Config.options.phone.scrcpy.useWireless && Config.options.phone.scrcpy.autoWirelessIp
+            text: KdeConnectService.resolvedWirelessHost !== "" ? Translation.tr("Will connect to %1").arg(KdeConnectService.resolvedWirelessHost) : Translation.tr("Waiting for KDE Connect to report the phone's IP…")
+            font.pixelSize: Appearance.font.pixelSize.smaller
+            color: Appearance.colors.colSubtext
+            wrapMode: Text.Wrap
+        }
+
         ConfigTextField {
             icon: "dns"
             text: Translation.tr("Wireless IP")
@@ -48,7 +68,8 @@ ContentPage {
             textField.onTextChanged: {
                 Config.options.phone.scrcpy.wirelessIp = textField.text;
             }
-            enabled: Config.options.phone.scrcpy.useWireless
+            visible: Config.options.phone.scrcpy.useWireless && !Config.options.phone.scrcpy.autoWirelessIp
+            enabled: visible
         }
 
         ConfigTextField {
@@ -59,7 +80,8 @@ ContentPage {
             textField.onTextChanged: {
                 Config.options.phone.scrcpy.wirelessPort = textField.text;
             }
-            enabled: Config.options.phone.scrcpy.useWireless
+            visible: Config.options.phone.scrcpy.useWireless && !Config.options.phone.scrcpy.autoWirelessIp
+            enabled: visible
         }
 
         ConfigSwitch {

--- a/dots/.config/quickshell/ii/scripts/kdeconnect/monitor.py
+++ b/dots/.config/quickshell/ii/scripts/kdeconnect/monitor.py
@@ -177,6 +177,7 @@ def fetch_device_props(dev_id):
         "paired": bool(props.get("isPaired", False)),
         "supported_plugins": [str(p) for p in props.get("supportedPlugins", [])],
         "loaded_plugins": [str(p) for p in props.get("loadedPlugins", [])],
+        "reachableAddresses": [str(a) for a in props.get("reachableAddresses", [])],
     }
 
 

--- a/dots/.config/quickshell/ii/services/KdeConnectService.qml
+++ b/dots/.config/quickshell/ii/services/KdeConnectService.qml
@@ -90,6 +90,32 @@ Singleton {
      *  quick actions (screenshot, power key, volume, am start). */
     property bool adbReachable: false
 
+    /** Live wireless ADB target ("ip:port") the next scrcpy launch will use.
+     *  In auto mode this tracks KDE Connect's reported reachable address so
+     *  the user never has to type an IP that changes (VPN, DHCP, etc.).
+     *  Empty when no host can be resolved. Bound reactively — reads the
+     *  device list, active device id, and scrcpy config so it refreshes
+     *  whenever any of them change. */
+    /** "ip:port" discovered via mDNS (avahi) for the phone's Android 11+
+     *  wireless-debugging service. Carries the CURRENT randomly-assigned
+     *  port, which changes on every toggle/reboot. Empty when not found
+     *  (avahi missing, wireless debugging off, or nothing on the network).
+     *  Refreshed by mdnsProber while wireless auto mode is active. */
+    property string mdnsWirelessHost: ""
+
+    readonly property string resolvedWirelessHost: {
+        root.devices
+        root.activeDeviceId
+        root.mdnsWirelessHost
+        const c = (Config.options.phone && Config.options.phone.scrcpy) ? Config.options.phone.scrcpy : null
+        if (c) {
+            c.autoWirelessIp
+            c.wirelessIp
+            c.wirelessPort
+        }
+        return root._resolveWirelessHost(root.activeDeviceId)
+    }
+
     property var notifications: []
     readonly property int notificationCount: notifications.length
     onNotificationsChanged: {
@@ -546,6 +572,7 @@ Singleton {
             signalStrength: ev.signalStrength ?? 0,
             supportedPlugins: ev.supported_plugins ?? [],
             loadedPlugins: ev.loaded_plugins ?? [],
+            reachableAddresses: ev.reachableAddresses ?? [],
         }
         if (idx < 0) devices.push(normalized)
         else devices[idx] = Object.assign({}, devices[idx], normalized)
@@ -632,6 +659,8 @@ Singleton {
         }
         if ("loadedPlugins" in changed) patch.loadedPlugins = changed.loadedPlugins.slice(0)
         if ("supportedPlugins" in changed) patch.supportedPlugins = changed.supportedPlugins.slice(0)
+        if ("reachableAddresses" in changed && changed.reachableAddresses)
+            patch.reachableAddresses = changed.reachableAddresses.slice(0)
         root._patchDevice(id, patch)
     }
 
@@ -1025,17 +1054,25 @@ Singleton {
     Process {
         id: adbProbeProc
         running: false
-        command: ["bash", "-c",
-            "if command -v adb >/dev/null 2>&1; then " +
-            "  IP=" + root._shellQuote((Config.options.phone && Config.options.phone.scrcpy)
-                                      ? (Config.options.phone.scrcpy.wirelessIp || "")
-                                      : "") + "; " +
-            "  if [ -n \"$IP\" ]; then " +
-            "    adb connect \"$IP\" 2>/dev/null; " +
-            "  fi; " +
-            "  STATE=$(adb get-state 2>/dev/null); " +
-            "  [ \"$STATE\" = \"device\" ] && exit 0 || exit 1; " +
-            "else exit 1; fi"]
+        command: {
+            const c = (Config.options.phone && Config.options.phone.scrcpy) ? Config.options.phone.scrcpy : null
+            const useWl = c && c.useWireless
+            const wantIp = useWl ? root._kdeConnectIp(root.activeDeviceId) : ""
+            const fallback = useWl ? root._resolveWirelessHost(root.activeDeviceId) : ""
+            const fb = fallback ? root._shellQuote(fallback) : "''"
+            // In wireless mode, discover the live ip:port via mDNS, falling
+            // back to the KDE Connect / manual host if avahi finds nothing.
+            const resolveIp = useWl
+                ? "IP=$(" + root._mdnsDiscoverSnippet(wantIp) + "); [ -z \"$IP\" ] && IP=" + fb + "; "
+                : "IP=''; "
+            return ["bash", "-c",
+                "if command -v adb >/dev/null 2>&1; then " +
+                resolveIp +
+                "  if [ -n \"$IP\" ]; then adb connect \"$IP\" 2>/dev/null; fi; " +
+                "  STATE=$(adb get-state 2>/dev/null); " +
+                "  [ \"$STATE\" = \"device\" ] && exit 0 || exit 1; " +
+                "else exit 1; fi"]
+        }
         onExited: (code, status) => {
             const now = (code === 0)
             if (now !== root.adbReachable) {
@@ -1048,6 +1085,38 @@ Singleton {
     function _probeAdb() {
         adbProbeProc.running = false
         adbProbeProc.running = true
+    }
+
+    // ─── mDNS discovery of the phone's wireless-debugging port ────
+    // Android 11+ wireless debugging listens on a RANDOM port that changes
+    // on every toggle/reboot. avahi discovers the live ip:port so the user
+    // never has to look it up. Only runs while wireless auto mode is on.
+    Timer {
+        id: mdnsProber
+        interval: 12000
+        repeat: true
+        triggeredOnStart: true
+        running: root.ready && root._enabled
+            && Config.options.phone && Config.options.phone.scrcpy
+            && Config.options.phone.scrcpy.useWireless
+            && Config.options.phone.scrcpy.autoWirelessIp
+        onTriggered: root._probeMdns()
+    }
+
+    Process {
+        id: mdnsProbeProc
+        running: false
+        command: ["bash", "-c", root._mdnsDiscoverSnippet(root._kdeConnectIp(root.activeDeviceId))]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                root.mdnsWirelessHost = this.text.trim()
+            }
+        }
+    }
+
+    function _probeMdns() {
+        mdnsProbeProc.running = false
+        mdnsProbeProc.running = true
     }
 
     /**
@@ -1092,13 +1161,12 @@ Singleton {
 
         const scrcpyConf = Config.options.phone ? Config.options.phone.scrcpy : null
         const useWireless = scrcpyConf ? scrcpyConf.useWireless : false
-        const wirelessIp = scrcpyConf ? (scrcpyConf.wirelessIp || "") : ""
-        const wirelessPort = scrcpyConf ? (scrcpyConf.wirelessPort || "5555") : "5555"
+        const wirelessHost = useWireless ? root._resolveWirelessHost(root.activeDeviceId) : ""
 
         // Build shell command — delay monkey by 1s so scrcpy starts first.
         let cmd = ""
-        if (useWireless && wirelessIp.length > 0) {
-            cmd += "adb connect " + root._shellQuote(wirelessIp + ":" + wirelessPort) + " >/dev/null 2>&1; "
+        if (wirelessHost.length > 0) {
+            cmd += "adb connect " + root._shellQuote(wirelessHost) + " >/dev/null 2>&1; "
         }
         cmd += "sleep 1; "
         cmd += "adb shell monkey -p " + root._shellQuote(pkg) +
@@ -1279,6 +1347,15 @@ Singleton {
     property string _wirelessPromptDevId: ""
 
     function promptWirelessConnect(devId) {
+        // Auto mode: skip the IP:port dialog entirely — resolve the host
+        // live from KDE Connect and connect straight away.
+        const c = (Config.options.phone && Config.options.phone.scrcpy) ? Config.options.phone.scrcpy : null
+        if (c && c.autoWirelessIp && root._resolveWirelessHost(devId)) {
+            c.useWireless = true
+            root.launchScrcpy(devId, "wireless")
+            return
+        }
+
         root._wirelessPromptDevId = devId || ""
         wirelessPromptProc.command = [
             "bash", "-c",
@@ -1316,6 +1393,8 @@ Singleton {
                         Config.options.phone.scrcpy.wirelessIp = ip
                         Config.options.phone.scrcpy.wirelessPort = port
                         Config.options.phone.scrcpy.useWireless = true
+                        // User typed an explicit IP — respect it over auto.
+                        Config.options.phone.scrcpy.autoWirelessIp = false
                     }
                     root.launchScrcpy(root._wirelessPromptDevId, "wireless")
                 }
@@ -1327,6 +1406,60 @@ Singleton {
         return "'" + String(s).replace(/'/g, "'\\''") + "'"
     }
 
+    /** Bash pipeline that prints "ip:port" for the phone's Android 11+
+     *  wireless-debugging endpoint (_adb-tls-connect._tcp), discovered via
+     *  mDNS with avahi. This is how we learn the CURRENT random port. When
+     *  `wantIp` is given, the line whose address matches it wins (so the
+     *  right phone is picked with several on the LAN); otherwise the first
+     *  discovered service is used. Prints nothing if avahi is missing or no
+     *  service is advertised. */
+    function _mdnsDiscoverSnippet(wantIp) {
+        const want = root._shellQuote(wantIp || "")
+        return "avahi-browse -rpt _adb-tls-connect._tcp 2>/dev/null | "
+            + "awk -F';' -v want=" + want + " '"
+            + "/^=/ { if (want != \"\" && $8 == want) { print $8\":\"$9; found = 1; exit } "
+            + "if (f == \"\") f = $8\":\"$9 } "
+            + "END { if (!found && f != \"\") print f }'"
+    }
+
+    /** First non-empty LAN address KDE Connect currently reports for the
+     *  device — the address it is actively using, so it stays correct
+     *  across DHCP/VPN changes. Empty string if none is known yet. */
+    function _kdeConnectIp(devId) {
+        const dev = root._findDevice(devId || root.activeDeviceId)
+        if (!dev) return ""
+        const addrs = dev.reachableAddresses || []
+        for (let i = 0; i < addrs.length; i++) {
+            const a = String(addrs[i]).trim()
+            if (a.length > 0) return a
+        }
+        return ""
+    }
+
+    /** Resolves the wireless ADB target as "ip:port". In auto mode the IP
+     *  comes from KDE Connect (falling back to the manual field if KDE
+     *  Connect has nothing yet); in manual mode it's the configured field.
+     *  Returns "" when no IP is available. */
+    function _resolveWirelessHost(devId) {
+        const c = (Config.options.phone && Config.options.phone.scrcpy) ? Config.options.phone.scrcpy : null
+        if (!c) return ""
+        // Auto mode: prefer the mDNS-discovered host — it carries the phone's
+        // current wireless-debugging port. Only trust the cache when its IP
+        // matches this device (or the device's IP is unknown).
+        if (c.autoWirelessIp && root.mdnsWirelessHost.indexOf(":") > 0) {
+            const mip = root.mdnsWirelessHost.split(":")[0]
+            const kip = root._kdeConnectIp(devId)
+            if (!kip || mip === kip) return root.mdnsWirelessHost
+        }
+        const port = (c.wirelessPort && String(c.wirelessPort).trim() !== "")
+            ? String(c.wirelessPort).trim() : "5555"
+        let ip = ""
+        if (c.autoWirelessIp) ip = root._kdeConnectIp(devId)
+        if (!ip) ip = (c.wirelessIp || "").trim()
+        if (!ip) return ""
+        return (ip.indexOf(":") < 0) ? (ip + ":" + port) : ip
+    }
+
     function launchScrcpy(devId, mode, deepLink) {
         if (!devId) return
 
@@ -1334,10 +1467,8 @@ Singleton {
         // Without it, scrcpy has no device to connect to and the error is
         // just "unknown" — unhelpful. Early return with a descriptive message.
         if (!root.adbReachable) {
-            const wirelessIp = Config.options.phone && Config.options.phone.scrcpy
-                ? (Config.options.phone.scrcpy.wirelessIp || "").trim()
-                : ""
-            if (!wirelessIp || mode === "usb") {
+            const wirelessHostPreflight = root._resolveWirelessHost(devId)
+            if (!wirelessHostPreflight || mode === "usb") {
                 root.scrcpyLaunchError = Translation.tr("Phone not connected via ADB.\n\n"
                     + "To mirror your screen you need ADB access:\n"
                     + "  • USB: plug your phone AND enable USB debugging\n"
@@ -1436,22 +1567,20 @@ Singleton {
         if (maxSize > 0) scrcpyArgs.push("--max-size=" + maxSize)
         if (videoBuffer > 0) scrcpyArgs.push("--video-buffer=" + videoBuffer)
 
-        let wirelessHost = ""
-        if (useWireless && wirelessIp && wirelessIp.trim() !== "") {
-            const ip = wirelessIp.trim()
-            const port = (wirelessPort && wirelessPort.trim() !== "") ? wirelessPort.trim() : "5555"
-            if (ip.indexOf(":") < 0) {
-                wirelessHost = ip + ":" + port
-            } else {
-                wirelessHost = ip
-            }
-        }
-
         let baseCmd = ""
-        if (useWireless && wirelessHost !== "") {
-            const quotedHost = root._shellQuote(wirelessHost)
-            baseCmd = "adb connect " + quotedHost + " && "
-            scrcpyArgs.push("--serial=" + quotedHost)
+        if (useWireless) {
+            // Android 11+ wireless debugging uses a RANDOM port that changes
+            // on every toggle/reboot, so resolve the live ip:port via mDNS
+            // (avahi) at launch time. Fall back to the KDE Connect / manual
+            // host (e.g. legacy `adb tcpip 5555`) when mDNS finds nothing.
+            const wantIp = root._kdeConnectIp(devId)
+            const fallback = root._resolveWirelessHost(devId)
+            const fb = fallback ? root._shellQuote(fallback) : "''"
+            baseCmd = "HOST=$(" + root._mdnsDiscoverSnippet(wantIp) + "); "
+                + "[ -z \"$HOST\" ] && HOST=" + fb + "; "
+                + "adb connect \"$HOST\" && "
+            // Unquoted so the shell expands $HOST inside the same bash -c.
+            scrcpyArgs.push("--serial=\"$HOST\"")
         }
 
         // Deep-link pre-launch: if we got an `am start` intent from a


### PR DESCRIPTION
## Describe your changes

Mirroring my phone over scrcpy on cable is one click, but over WiFi it was a pain — I had to type in the phone's IP and port by hand every time, and both change constantly (especially on VPN, and Android 11+ wireless debugging hands out a *random* port on every toggle/reboot). So a fixed `5555` just fails with "connection refused".

This makes wireless scrcpy fully automatic:

- **IP** comes live from KDE Connect. I pipe the device's `reachableAddresses` DBus property through `monitor.py` → `KdeConnectService`, so it's the real, VPN-aware LAN address without any manual entry. (This also fixes the previously-dead "Copy IP" button, which was dropping the property before it reached QML.)
- **Port** is discovered via mDNS. `adb mdns services` is broken here, so I shell out to `avahi-browse -rpt _adb-tls-connect._tcp` and match the `_adb-tls-connect._tcp` record whose IP equals the active phone's KDE Connect IP, yielding the current `ip:port` (e.g. `10.245.196.109:38333`). This runs inline at launch and on a 12 s prober `Timer` that feeds the settings readout.
- New `phone.scrcpy.autoWirelessIp` option (on by default). `_resolveWirelessHost()` layers: mDNS host (correct random port) → KDE Connect IP + configured port → manual field. In auto mode `launchScrcpy` does a fresh avahi discovery and passes `--serial=<host>`.
- **UI**: added an "Auto-detect IP (KDE Connect)" switch plus a live "Will connect to `<ip:port>`" readout in both the sidebar phone page (`PhoneScrcpyPage.qml`) and the Settings › Devices & Phone tab (`DevicesPhoneConfig.qml`). When auto is on, the manual Wireless IP / Port fields are hidden entirely.
- Legacy `adb tcpip 5555` remains as the fallback path (KDE Connect IP + fixed port) for phones not using wireless debugging.

Setup instructions in the sidebar page were rewritten to describe the wireless-debugging / mDNS flow.

## Is it ready? Questions/feedback needed?

Working on my setup: verified the avahi discovery returns `10.245.196.109:38333`, `adb connect` succeeds (phone already ADB-paired), and scrcpy launches with the discovered serial. Caveats:

- Requires `avahi-daemon` running and the phone's Wireless debugging kept ON (screen unlocked on some ROMs). Only tested on one Samsung device over one VPN — I don't know how other ROMs advertise the `_adb-tls-connect._tcp` record, or the first-time `adb pair` path (mine was already paired).
- The mDNS match keys on the KDE Connect IP; if KDE Connect isn't connected, it falls back to the manual field. Untested on the vertical bar / Waffle surfaces.
- Requires a quickshell restart for the new `monitor.py` to take effect (hot-reload covers the QML but not the running Python monitor).
