### PR TITLE
FEAT: Active window "On every monitor" option

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -933,6 +933,7 @@ Singleton {
                 property JsonObject activeWindow: JsonObject {
                     property bool fixedSize: false
                     property int customSize: 225
+                    property bool showOnAllMonitors: false
                 }
 
                 property JsonObject autoHide: JsonObject {

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/activeWindow/ActiveWindow.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/activeWindow/ActiveWindow.qml
@@ -25,10 +25,15 @@ Item {
     property int maxPopupWidth: 600
     readonly property int fixedSize: Config.options.bar.activeWindow.customSize
 
-    property string appClassText: root.focusingThisMonitor && root.activeWindow?.activated && root.biggestWindow ? 
+    readonly property bool shouldShowActiveWindow: root.activeWindow?.activated && (
+        Config.options.bar.activeWindow.showOnAllMonitors
+            || (root.focusingThisMonitor && root.biggestWindow)
+    )
+
+    property string appClassText: root.shouldShowActiveWindow ?
                 root.activeWindow?.appId : (root.biggestWindow?.class) ?? Translation.tr("Desktop")
-                
-    property string appTitleText: root.focusingThisMonitor && root.activeWindow?.activated && root.biggestWindow ? 
+
+    property string appTitleText: root.shouldShowActiveWindow ?
                 root.activeWindow?.title : (root.biggestWindow?.title) ?? `${Translation.tr("Workspace")} ${monitor?.activeWorkspace?.id ?? 1}`
     
     implicitHeight: root.vertical && isFixedSize ? fixedSize : (root.vertical ? Math.max(classText.implicitWidth, titleText.implicitWidth) + 20 : Appearance.sizes.baseBarHeight)

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/activeWindow/ExpressiveActiveWindow.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/activeWindow/ExpressiveActiveWindow.qml
@@ -25,10 +25,15 @@ Item {
     property int maxPopupWidth: 600
     readonly property int fixedSize: Config.options.bar.activeWindow.customSize
 
-    property string appClassText: root.focusingThisMonitor && root.activeWindow?.activated && root.biggestWindow ? 
+    readonly property bool shouldShowActiveWindow: root.activeWindow?.activated && (
+        Config.options.bar.activeWindow.showOnAllMonitors
+            || (root.focusingThisMonitor && root.biggestWindow)
+    )
+
+    property string appClassText: root.shouldShowActiveWindow ?
                 root.activeWindow?.appId : (root.biggestWindow?.class) ?? Translation.tr("Desktop")
-                
-    property string appTitleText: root.focusingThisMonitor && root.activeWindow?.activated && root.biggestWindow ? 
+
+    property string appTitleText: root.shouldShowActiveWindow ?
                 root.activeWindow?.title : (root.biggestWindow?.title) ?? `${Translation.tr("Workspace")} ${monitor?.activeWorkspace?.id ?? 1}`
     
     implicitHeight: root.vertical && isFixedSize ? fixedSize : (root.vertical ? Math.max(expressiveText.implicitWidth) + 30 : Appearance.sizes.baseBarHeight)

--- a/dots/.config/quickshell/ii/modules/settings/configs/widgets/ActiveWindowConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/widgets/ActiveWindowConfig.qml
@@ -49,6 +49,23 @@ ContentPage {
         icon: "ad"
         title: Translation.tr("Active Window")
 
+        TipBox {
+            Layout.fillWidth: true
+            isFirst: true
+            text: Translation.tr(
+                "When off: the bar on the monitor you are using shows the focused window; bars on other monitors show the largest window on that workspace (or Workspace when empty). "
+                + "When on: every bar shows the same globally focused window.")
+        }
+
+        ConfigSwitch {
+            buttonIcon: "desktop_windows"
+            text: Translation.tr("Show focused window on every monitor")
+            checked: Config.options.bar.activeWindow.showOnAllMonitors
+            onCheckedChanged: {
+                Config.options.bar.activeWindow.showOnAllMonitors = checked;
+            }
+        }
+
         ConfigSwitch {
             buttonIcon: "crop_free"
             text: Translation.tr("Use fixed size")


### PR DESCRIPTION
## Describe your changes
adds new option to the "Active Window" widget
<img width="1710" height="436" alt="image" src="https://github.com/user-attachments/assets/e6d14ed7-7b61-421e-bc10-7b241ee7ca4d" />


<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yuh. Nuh-Uh.

