### PR TITLE
FIX: remove wifi icon on android toggle when having wired connection

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarDashboard/quickToggles/androidStyle/AndroidNetworkToggle.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarDashboard/quickToggles/androidStyle/AndroidNetworkToggle.qml
@@ -14,7 +14,7 @@ AndroidQuickToggleButton {
     tall1x2OverrideComponent: netTall1x2
     wide2x2OverrideComponent: netWide2x2
 
-    backgroundIcon: "wifi"
+    backgroundIcon: Network.ethernet ? "" : "wifi"
 
     // ── 1x2 (tall, narrow) component ─────────────────────────────────────────
     Component {


### PR DESCRIPTION
## Describe your changes
before when using wired internet android toggle for network had wifi icon behind 
<img width="207" height="176" alt="image" src="https://github.com/user-attachments/assets/19690ef4-6ddd-48a7-8d0c-2a9c0ff33958" />

this one fixes it 
<img width="265" height="194" alt="image" src="https://github.com/user-attachments/assets/15e3eb3f-6ee0-4410-988d-31fbf7fa7b12" />


<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yes, no

