### PR TITLE
ENH: cheatsheet

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -1399,7 +1399,7 @@ Singleton {
                 property bool splitButtons: false
                 property bool useMouseSymbol: false
                 property bool useFnSymbol: false
-                property bool filterUnbinds: false
+                property bool filterUnbinds: true
                 property bool enableGmail: true
                 property bool enableTimetable: true
                 property bool timetableTodayFirst: false

--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybinds.qml
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybinds.qml
@@ -23,7 +23,12 @@ Item {
     readonly property var rawKeybinds: {
         const defaultKeybinds = HyprlandKeybinds.defaultKeybinds.children ?? [];
         const userKeybinds = HyprlandKeybinds.userKeybinds.children ?? [];
-        const unbinds = Config.options.cheatsheet.filterUnbinds ? parseUnbinds(userKeybinds) : [];
+        const unbinds = Config.options.cheatsheet.filterUnbinds
+            ? [
+                ...(HyprlandKeybinds.userKeybinds.unbinds ?? []),
+                ...parseUnbinds(userKeybinds)
+            ]
+            : [];
         return [...(processKeymaps(defaultKeybinds, unbinds) ?? []), ...(processKeymaps(userKeybinds) ?? [])];
     }
 
@@ -31,22 +36,31 @@ Item {
 
     function flattenSections(tree) {
         const sections = [];
+        const byName = {};
         if (!tree) return sections;
-        for (let i = 0; i < tree.length; i++) {
-            const node = tree[i];
-            if (node.keybinds && node.keybinds.length > 0) {
-                sections.push({
-                    name: node.name || "",
-                    keybinds: node.keybinds
-                });
-            }
-            if (node.children && node.children.length > 0) {
-                const childSections = flattenSections(node.children);
-                for (let j = 0; j < childSections.length; j++) {
-                    sections.push(childSections[j]);
+
+        function walk(nodes) {
+            for (const node of nodes ?? []) {
+                const keybinds = node.keybinds;
+                if (keybinds?.length) {
+                    const name = node.name || "";
+                    const existing = byName[name];
+                    if (existing) {
+                        existing.keybinds.push(...keybinds);
+                    } else {
+                        byName[name] = {
+                            name,
+                            keybinds: [...keybinds],
+                            defaultCount: keybinds.length // customs append after this
+                        };
+                        sections.push(byName[name]);
+                    }
                 }
+                walk(node.children);
             }
         }
+
+        walk(tree);
         return sections;
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybindsCategory.qml
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/CheatsheetKeybindsCategory.qml
@@ -18,14 +18,22 @@ Rectangle {
     readonly property string iconName: cheatsheetRoot.categoryIcons[sectionData.name] ?? "keyboard"
     readonly property string shapeName: cheatsheetRoot.sectionShapes[sectionIndex % cheatsheetRoot.sectionShapes.length]
 
-    readonly property bool hasMatches: {
-        if (bypassFilter || cheatsheetRoot.filter === "") return true;
-        const kbs = sectionData.keybinds;
+    readonly property int defaultCount: sectionData.defaultCount ?? sectionData.keybinds.length
+    readonly property var defaultKeybinds: sectionData.keybinds.slice(0, defaultCount)
+    readonly property var customKeybinds: sectionData.keybinds.slice(defaultCount)
+
+    function listHasMatches(kbs) {
+        if (bypassFilter || cheatsheetRoot.filter === "") return kbs.length > 0;
         for (let i = 0; i < kbs.length; i++) {
             if (cheatsheetRoot.bindMatches(kbs[i], sectionData.name)) return true;
         }
         return false;
     }
+
+    readonly property bool hasDefaultMatches: listHasMatches(defaultKeybinds)
+    readonly property bool hasCustomMatches: listHasMatches(customKeybinds)
+    readonly property bool hasMatches: hasDefaultMatches || hasCustomMatches
+    readonly property bool showSourceSplit: hasDefaultMatches && hasCustomMatches
 
     visible: hasMatches || opacity > 0
     opacity: hasMatches ? 1.0 : 0.0
@@ -104,6 +112,83 @@ Rectangle {
         }
     }
 
+    component KeybindRow: Row {
+        id: bindRow
+        required property var modelData
+        readonly property bool matches: root.bypassFilter || cheatsheetRoot.bindMatches(bindRow.modelData, root.sectionData.name)
+
+        spacing: 12
+        height: matches ? implicitHeight : 0
+        opacity: matches ? 1.0 : 0.0
+        visible: matches || opacity > 0
+        clip: true
+
+        Behavior on height {
+            NumberAnimation {
+                duration: 180
+                easing.type: Easing.BezierSpline
+                easing.bezierCurve: Appearance.animationCurves.emphasized
+            }
+        }
+        Behavior on opacity {
+            NumberAnimation {
+                duration: 180
+                easing.type: Easing.BezierSpline
+                easing.bezierCurve: Appearance.animationCurves.emphasized
+            }
+        }
+
+        Row {
+            spacing: 4
+            Repeater {
+                model: bindRow.modelData.mods
+                delegate: Row {
+                    required property var modelData
+                    required property int index
+                    spacing: 4
+
+                    StyledText {
+                        anchors.verticalCenter: parent.verticalCenter
+                        visible: Config.options.cheatsheet.splitButtons && index > 0
+                        text: "+"
+                        font.family: Appearance.font.family.monospace
+                        font.pixelSize: Config.options.cheatsheet.fontSize.key
+                        font.weight: Font.Bold
+                        color: Appearance.colors.colPrimary
+                    }
+                    KeyChip {
+                        chipText: cheatsheetRoot.keySubstitutions[modelData] || modelData
+                        bgColor: Appearance.colors.colSurfaceContainerLow
+                        textColor: Appearance.colors.colOnSurface
+                    }
+                }
+            }
+            StyledText {
+                anchors.verticalCenter: parent.verticalCenter
+                visible: Config.options.cheatsheet.splitButtons && !cheatsheetRoot.keyBlacklist.includes(bindRow.modelData.key) && bindRow.modelData.mods.length > 0
+                text: "+"
+                font.family: Appearance.font.family.monospace
+                font.pixelSize: Config.options.cheatsheet.fontSize.key
+                font.weight: Font.Bold
+                color: Appearance.colors.colPrimary
+            }
+            KeyChip {
+                visible: Config.options.cheatsheet.splitButtons && !cheatsheetRoot.keyBlacklist.includes(bindRow.modelData.key)
+                chipText: cheatsheetRoot.keySubstitutions[bindRow.modelData.key] || bindRow.modelData.key
+                bgColor: Appearance.colors.colPrimary
+                textColor: Appearance.colors.colOnPrimary
+            }
+        }
+
+        StyledText {
+            anchors.verticalCenter: parent.verticalCenter
+            font.pixelSize: Config.options.cheatsheet.fontSize.comment || Appearance.font.pixelSize.smaller
+            color: Appearance.colors.colOnSurface
+            opacity: 0.7
+            text: bindRow.modelData.comment || ""
+        }
+    }
+
     Column {
         id: cardContent
         anchors {
@@ -160,84 +245,30 @@ Rectangle {
             anchors.right: parent.right
 
             Repeater {
-                model: root.sectionData.keybinds
+                model: root.defaultKeybinds
+                delegate: KeybindRow {}
+            }
 
-                delegate: Row {
-                    id: bindRow
-                    required property var modelData
-                    readonly property bool matches: root.bypassFilter || cheatsheetRoot.bindMatches(bindRow.modelData, root.sectionData.name)
+            Item {
+                visible: root.showSourceSplit
+                height: visible ? 9 : 0
+                anchors.left: parent.left
+                anchors.right: parent.right
 
-                    spacing: 12
-                    height: matches ? implicitHeight : 0
-                    opacity: matches ? 1.0 : 0.0
-                    visible: matches || opacity > 0
-                    clip: true
-
-                    Behavior on height {
-                        NumberAnimation {
-                            duration: 180
-                            easing.type: Easing.BezierSpline
-                            easing.bezierCurve: Appearance.animationCurves.emphasized
-                        }
-                    }
-                    Behavior on opacity {
-                        NumberAnimation {
-                            duration: 180
-                            easing.type: Easing.BezierSpline
-                            easing.bezierCurve: Appearance.animationCurves.emphasized
-                        }
-                    }
-
-                    Row {
-                        spacing: 4
-                        Repeater {
-                            model: bindRow.modelData.mods
-                            delegate: Row {
-                                required property var modelData
-                                required property int index
-                                spacing: 4
-
-                                StyledText {
-                                    anchors.verticalCenter: parent.verticalCenter
-                                    visible: Config.options.cheatsheet.splitButtons && index > 0
-                                    text: "+"
-                                    font.family: Appearance.font.family.monospace
-                                    font.pixelSize: Config.options.cheatsheet.fontSize.key
-                                    font.weight: Font.Bold
-                                    color: Appearance.colors.colPrimary
-                                }
-                                KeyChip {
-                                    chipText: cheatsheetRoot.keySubstitutions[modelData] || modelData
-                                    bgColor: Appearance.colors.colSurfaceContainerLow
-                                    textColor: Appearance.colors.colOnSurface
-                                }
-                            }
-                        }
-                        StyledText {
-                            anchors.verticalCenter: parent.verticalCenter
-                            visible: Config.options.cheatsheet.splitButtons && !cheatsheetRoot.keyBlacklist.includes(bindRow.modelData.key) && bindRow.modelData.mods.length > 0
-                            text: "+"
-                            font.family: Appearance.font.family.monospace
-                            font.pixelSize: Config.options.cheatsheet.fontSize.key
-                            font.weight: Font.Bold
-                            color: Appearance.colors.colPrimary
-                        }
-                        KeyChip {
-                            visible: Config.options.cheatsheet.splitButtons && !cheatsheetRoot.keyBlacklist.includes(bindRow.modelData.key)
-                            chipText: cheatsheetRoot.keySubstitutions[bindRow.modelData.key] || bindRow.modelData.key
-                            bgColor: Appearance.colors.colPrimary
-                            textColor: Appearance.colors.colOnPrimary
-                        }
-                    }
-
-                    StyledText {
-                        anchors.verticalCenter: parent.verticalCenter
-                        font.pixelSize: Config.options.cheatsheet.fontSize.comment || Appearance.font.pixelSize.smaller
-                        color: Appearance.colors.colOnSurface
-                        opacity: 0.7
-                        text: bindRow.modelData.comment || ""
-                    }
+                Rectangle {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    height: 1
+                    radius: 1
+                    color: Appearance.colors.colOutlineVariant
+                    opacity: 0.45
                 }
+            }
+
+            Repeater {
+                model: root.customKeybinds
+                delegate: KeybindRow {}
             }
         }
     }

--- a/dots/.config/quickshell/ii/scripts/hyprland/get_keybinds.py
+++ b/dots/.config/quickshell/ii/scripts/hyprland/get_keybinds.py
@@ -173,24 +173,28 @@ def parse_lua_binds(path):
 
         i += 1
 
-    # Wrap orphan root keybinds into an implicit section
-    if root.get("keybinds") and len(root["keybinds"]) > 0:
-        implicit = Section([], list(root["keybinds"]), [], "Keybinds")
+    # Wrap orphan root keybinds/unbinds into an implicit section so QML
+    # (which walks .children) can discover them.
+    if (root.get("keybinds") and len(root["keybinds"]) > 0) or \
+       (root.get("unbinds") and len(root["unbinds"]) > 0):
+        implicit = Section(
+            [],
+            list(root.get("keybinds") or []),
+            list(root.get("unbinds") or []),
+            "Keybinds",
+        )
         root["children"].insert(0, implicit)
         root["keybinds"] = []
+        root["unbinds"] = []
 
     # Nest each section's direct keybinds into a synthetic child sub-section
-    # so the QML parseKeymaps function sees child.children with keybind data
+    # so the QML parseKeymaps function sees child.children with keybind data.
+    # Unbinds stay on the section itself — parseUnbinds walks all nodes.
     for section in root["children"]:
         if section.get("keybinds") and len(section["keybinds"]) > 0:
             sub = Section([], list(section["keybinds"]), [], section.get("name", ""))
             section["children"].append(sub)
             section["keybinds"] = []
-        # Also handle unbinds (wrap into child)
-        if section.get("unbinds") and len(section["unbinds"]) > 0:
-            for child in section["children"]:
-                if not child.get("unbinds"):
-                    child["unbinds"] = []
 
     return root
 
@@ -213,13 +217,13 @@ def process_lua_bind(bind_src, current, is_unbind=False):
     if '[hidden]' in comment or '[ignore]' in comment:
         return
 
-    # Remove leading "Shell: ", "Utilities: ", etc. for display
-    # (the QML shows it as the comment text)
-    if not comment:
-        return  # skip binds without descriptions (they're internal)
-
     if is_unbind:
+        # Unbinds don't need descriptions — they only filter the cheatsheet
         current["unbinds"].append(Unbinding(mods, key, comment))
+        return
+
+    # Skip binds without descriptions (they're internal)
+    if not comment:
         return
 
     current["keybinds"].append(KeyBinding(mods, key, '', '', comment))


### PR DESCRIPTION
## Describe your changes
sets `filterUnbinds` on by default.
fixes a bug where unbinds weren't processed if unbind didn't have a description. silly, huh..
merges default and custom keybinds into one section and splits them with hr instead.
<img width="3608" height="1723" alt="image" src="https://github.com/user-attachments/assets/050933b3-c4a6-459f-95c2-72113c793f38" />
(screenshot includes some other changes, those are not really in this branch^^)

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
yeah. any improvements?

