### PR TITLE
feat(dock to panel): add docked panel bar widget

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/BarComponentRegistry.qml
+++ b/dots/.config/quickshell/ii/modules/common/BarComponentRegistry.qml
@@ -254,6 +254,12 @@ Singleton {
             styleConfigKey: "power",
             styleOptions: defaultStyleOptions,
             pageId: "power"
+        },
+        {
+            id: "dock_to_panel",
+            icon: "apps",
+            title: "Dock to Panel",
+            configPage: "DockToPanelConfig.qml"
         }
     ]
 

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -1455,8 +1455,8 @@ Singleton {
                 property int buttonSpacing: 2
                 property bool enableWorkspaceScroll: false
                 property bool alignToWorkspace: false
-                property bool enableTooltip: true
-                property bool enablePreview: true
+                property bool enableTooltip: false
+                property bool enablePreview: false
             }
 
             property JsonObject hyprland: JsonObject {

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -1457,6 +1457,8 @@ Singleton {
                 property bool alignToWorkspace: false
                 property bool enableTooltip: false
                 property bool enablePreview: false
+                property bool enableMacOsMagnification: false
+                property real macOsMagnificationScale: 1.6
             }
 
             property JsonObject hyprland: JsonObject {

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -1450,6 +1450,11 @@ Singleton {
                 property list<string> order: ["pin", "app:org.kde.dolphin", "app:kitty", "runningApps", "media", "weather", "trash", "overview"]
             }
 
+            property JsonObject dockToPanel: JsonObject {
+                property int iconSize: 25
+                property int buttonSpacing: 2
+            }
+
             property JsonObject hyprland: JsonObject {
                 property string defaultHyprlandLayout: "dwindle" // Options: dwindle, monocle, master // It's best to not use scrolling
             }

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -1453,8 +1453,10 @@ Singleton {
             property JsonObject dockToPanel: JsonObject {
                 property int iconSize: 25
                 property int buttonSpacing: 2
-                property bool enableWorkspaceScroll: true
+                property bool enableWorkspaceScroll: false
                 property bool alignToWorkspace: false
+                property bool enableTooltip: true
+                property bool enablePreview: true
             }
 
             property JsonObject hyprland: JsonObject {

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -1453,6 +1453,8 @@ Singleton {
             property JsonObject dockToPanel: JsonObject {
                 property int iconSize: 25
                 property int buttonSpacing: 2
+                property bool enableWorkspaceScroll: true
+                property bool alignToWorkspace: false
             }
 
             property JsonObject hyprland: JsonObject {

--- a/dots/.config/quickshell/ii/modules/common/SettingsPageRegistry.qml
+++ b/dots/.config/quickshell/ii/modules/common/SettingsPageRegistry.qml
@@ -43,7 +43,7 @@ Singleton {
         "name": "Bar",
         "icon": "space_bar",
         "component": "modules/settings/configs/BarConfig.qml",
-        "subPages": ["widgets/ActiveWindowConfig.qml", "widgets/MediaPlayerConfig.qml", "widgets/UtilButtonsConfig.qml", "widgets/KeyboardLayoutConfig.qml", "widgets/SystemMonitorConfig.qml", "widgets/IndicatorsConfig.qml", "widgets/SportsConfig.qml", "widgets/BluetoothConfig.qml", "widgets/SystemTrayConfig.qml", "widgets/BatteryConfig.qml", "widgets/DashboardButtonConfig.qml", "widgets/ClockDateWidgetConfig.qml", "widgets/WaffleTweaksConfig.qml"],
+        "subPages": ["widgets/ActiveWindowConfig.qml", "widgets/MediaPlayerConfig.qml", "widgets/UtilButtonsConfig.qml", "widgets/KeyboardLayoutConfig.qml", "widgets/SystemMonitorConfig.qml", "widgets/IndicatorsConfig.qml", "widgets/SportsConfig.qml", "widgets/BluetoothConfig.qml", "widgets/SystemTrayConfig.qml", "widgets/BatteryConfig.qml", "widgets/DashboardButtonConfig.qml", "widgets/ClockDateWidgetConfig.qml", "widgets/WaffleTweaksConfig.qml", "widgets/DockToPanelConfig.qml"],
         "aliases": ["Bar & Status Bar", "Status Bar", "Shell mode", "Waffle"]
     }, {
         "id": "wallpaper",

--- a/dots/.config/quickshell/ii/modules/common/widgets/RippleButton.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/RippleButton.qml
@@ -24,6 +24,8 @@ Button {
     property var altAction
     property var middleClickAction
     property var backClickAction
+    property var enteredAction
+    property var exitedAction
 
     property bool useDynamicRadius: false
 
@@ -229,8 +231,15 @@ Button {
 
     MouseArea {
         anchors.fill: parent
+        hoverEnabled: root.hoverEnabled
         cursorShape: root.pointingHandCursor ? Qt.PointingHandCursor : Qt.ArrowCursor
         acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton | Qt.BackButton | Qt.ExtraButton1
+        onEntered: {
+            if (root.enteredAction) root.enteredAction()
+        }
+        onExited: {
+            if (root.exitedAction) root.exitedAction()
+        }
         onPressed: event => {
             if (event.button === Qt.RightButton) {
                 if (root.altAction)

--- a/dots/.config/quickshell/ii/modules/common/widgets/RippleButton.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/RippleButton.qml
@@ -23,6 +23,7 @@ Button {
     property var releaseAction
     property var altAction
     property var middleClickAction
+    property var backClickAction
 
     property bool useDynamicRadius: false
 
@@ -229,7 +230,7 @@ Button {
     MouseArea {
         anchors.fill: parent
         cursorShape: root.pointingHandCursor ? Qt.PointingHandCursor : Qt.ArrowCursor
-        acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
+        acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton | Qt.BackButton | Qt.ExtraButton1
         onPressed: event => {
             if (event.button === Qt.RightButton) {
                 if (root.altAction)
@@ -239,6 +240,11 @@ Button {
             if (event.button === Qt.MiddleButton) {
                 if (root.middleClickAction)
                     root.middleClickAction();
+                return;
+            }
+            if (event.button === Qt.BackButton || event.button === Qt.ExtraButton1) {
+                if (root.backClickAction)
+                    root.backClickAction(event);
                 return;
             }
             root.down = true;

--- a/dots/.config/quickshell/ii/modules/ii/bar/BarComponent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarComponent.qml
@@ -27,6 +27,7 @@ import qs.modules.ii.bar.widgets.utilButtons
 import qs.modules.ii.bar.widgets.policies
 import qs.modules.ii.bar.widgets.timer
 import qs.modules.ii.bar.widgets.indicators
+import qs.modules.ii.bar.widgets.dockToPanel
 
 import qs.modules.ii.verticalBar as Vertical
 
@@ -471,6 +472,8 @@ Item {
             return phoneScrcpyIndicatorComp;
         case "screen_share_indicator":
             return screenshareIndicatorComp;
+        case "dock_to_panel":
+            return dockToPanelComp;
         default:
             return null;
         }
@@ -669,6 +672,12 @@ Item {
     Component {
         id: powerComp
         PowerButton {
+            vertical: rootItem.vertical
+        }
+    }
+    Component {
+        id: dockToPanelComp
+        DockToPanel {
             vertical: rootItem.vertical
         }
     }

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
@@ -385,16 +385,41 @@ Item {
                                     model: Math.min(slotItem.appEntry?.toplevels?.length ?? 0, 3)
                                     delegate: Rectangle {
                                         required property int index
+                                        readonly property int topCount: slotItem.appEntry?.toplevels?.length ?? 0
+                                        readonly property bool isSingleActive: slotItem.appActive && topCount === 1
+
                                         radius: Appearance.rounding.full
-                                        implicitWidth:  root.vertical
+                                        implicitWidth: root.vertical
                                             ? 2
-                                            : (slotItem.appEntry?.toplevels?.length ?? 0) <= 3 ? 4 : 2
+                                            : (isSingleActive ? 12 : (topCount <= 3 ? 4 : 2))
                                         implicitHeight: root.vertical
-                                            ? ((slotItem.appEntry?.toplevels?.length ?? 0) <= 3 ? 4 : 2)
+                                            ? (isSingleActive ? 12 : (topCount <= 3 ? 4 : 2))
                                             : 2
                                         color: slotItem.appActive
                                             ? Appearance.colors.colPrimary
-                                            : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.4)
+                                            : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.75)
+
+                                        Behavior on implicitWidth {
+                                            NumberAnimation {
+                                                duration: Appearance.animation.elementMoveFast.duration
+                                                easing.type: Appearance.animation.elementMoveFast.type
+                                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                            }
+                                        }
+                                        Behavior on implicitHeight {
+                                            NumberAnimation {
+                                                duration: Appearance.animation.elementMoveFast.duration
+                                                easing.type: Appearance.animation.elementMoveFast.type
+                                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                            }
+                                        }
+                                        Behavior on color {
+                                            ColorAnimation {
+                                                duration: Appearance.animation.elementMoveFast.duration
+                                                easing.type: Appearance.animation.elementMoveFast.type
+                                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -492,16 +517,41 @@ Item {
                                     model: Math.min(activeSlot.modelData.toplevels.length, 3)
                                     delegate: Rectangle {
                                         required property int index
+                                        readonly property int topCount: activeSlot.modelData.toplevels.length
+                                        readonly property bool isSingleActive: activeSlot.appIsActive && topCount === 1
+
                                         radius: Appearance.rounding.full
-                                        implicitWidth:  root.vertical
+                                        implicitWidth: root.vertical
                                             ? 2
-                                            : activeSlot.modelData.toplevels.length <= 3 ? 4 : 2
+                                            : (isSingleActive ? 12 : (topCount <= 3 ? 4 : 2))
                                         implicitHeight: root.vertical
-                                            ? (activeSlot.modelData.toplevels.length <= 3 ? 4 : 2)
+                                            ? (isSingleActive ? 12 : (topCount <= 3 ? 4 : 2))
                                             : 2
                                         color: activeSlot.appIsActive
                                             ? Appearance.colors.colPrimary
-                                            : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.4)
+                                            : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.75)
+
+                                        Behavior on implicitWidth {
+                                            NumberAnimation {
+                                                duration: Appearance.animation.elementMoveFast.duration
+                                                easing.type: Appearance.animation.elementMoveFast.type
+                                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                            }
+                                        }
+                                        Behavior on implicitHeight {
+                                            NumberAnimation {
+                                                duration: Appearance.animation.elementMoveFast.duration
+                                                easing.type: Appearance.animation.elementMoveFast.type
+                                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                            }
+                                        }
+                                        Behavior on color {
+                                            ColorAnimation {
+                                                duration: Appearance.animation.elementMoveFast.duration
+                                                easing.type: Appearance.animation.elementMoveFast.type
+                                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
@@ -21,9 +21,25 @@ Item {
     property bool vertical:    Config.options.bar.vertical
     property bool isMaterial:  Config.options.bar.cornerStyle === 3
     property var pinnedApps: Config.options?.dock.pinnedApps ?? []
-    property var activeUnpinned: TaskbarApps.apps.filter(
-        a => !a.pinned && a.appId !== "SEPARATOR" && a.toplevels.length > 0
-    )
+
+    readonly property HyprlandMonitor monitor: Hyprland.monitorFor(root.QsWindow.window?.screen)
+    readonly property int activeWsId: monitor?.activeWorkspace?.id ?? 1
+    readonly property bool alignToWorkspace: Config.options?.dockToPanel?.alignToWorkspace ?? false
+    readonly property bool enableWorkspaceScroll: Config.options?.dockToPanel?.enableWorkspaceScroll ?? true
+
+    // Scratchpad detection
+    readonly property var scratchpadWin: HyprlandData.windowList.find(w => w.workspace && w.workspace.name && w.workspace.name.startsWith("special"))
+    readonly property bool scratchpadOpen: scratchpadWin !== undefined
+    readonly property string scratchpadAppId: scratchpadWin ? TaskbarApps.normalizeAppId(scratchpadWin.class) : ""
+
+    property var activeUnpinned: TaskbarApps.apps.filter(a => {
+        if (a.pinned || a.appId === "SEPARATOR" || a.toplevels.length === 0) return false;
+        if (!root.alignToWorkspace) return true;
+        return a.toplevels.some(t => {
+            let win = HyprlandData.windowList.find(w => w.address === t.address || w.title === t.title);
+            return win && win.workspace && win.workspace.id === root.activeWsId;
+        });
+    })
     property bool showSeparator: _workOrder.length > 0 && activeUnpinned.length > 0
     property var  _workOrder:            pinnedApps.slice()
     property bool _dragging:             false
@@ -210,6 +226,20 @@ Item {
             }
         }
 
+        MouseArea {
+            anchors.fill: parent
+            z: -1
+            enabled: root.enableWorkspaceScroll
+            acceptedButtons: Qt.NoButton
+            onWheel: event => {
+                let delta = event.angleDelta.y !== 0 ? event.angleDelta.y : event.angleDelta.x;
+                if (delta > 0)
+                    Hyprland.dispatch("workspace e-1");
+                else if (delta < 0)
+                    Hyprland.dispatch("workspace e+1");
+            }
+        }
+
         Flow {
             id: flow
             anchors.centerIn: parent
@@ -227,8 +257,17 @@ Item {
 
                     property string appId:        root._workOrder[index] ?? ""
                     property var    appEntry:     TaskbarApps.apps.find(a => a.appId === appId) ?? null
+                    property var    appToplevels: {
+                        let list = appEntry?.toplevels ?? [];
+                        if (!root.alignToWorkspace) return list;
+                        return list.filter(t => {
+                            let win = HyprlandData.windowList.find(w => w.address === t.address || w.title === t.title);
+                            return win && win.workspace && win.workspace.id === root.activeWsId;
+                        });
+                    }
                     property var    deskEntry:    DesktopEntries.heuristicLookup(appId)
-                    property bool   appActive:    appEntry?.toplevels?.find(t => t.activated) !== undefined
+                    property bool   appActive:    appToplevels.find(t => t.activated) !== undefined
+                    readonly property bool isScratchpadApp: root.scratchpadOpen && TaskbarApps.normalizeAppId(appId) === root.scratchpadAppId
                     property int    _lastFocused: -1
 
                     // ── Animation properties (with clamping) ──────────────
@@ -251,7 +290,7 @@ Item {
                     }
 
                     z: isDragged ? 100 : 0
-                    opacity: isDragged ? 0.85 : 1
+                    opacity: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.25) : (isDragged ? 0.85 : 1.0)
                     scale: isDragged ? 1.05 : 1
 
                     Behavior on opacity {
@@ -342,6 +381,7 @@ Item {
                         }
                         middleClickAction: () => { slotItem.deskEntry?.execute() }
                         altAction:         () => { TaskbarApps.togglePin(slotItem.appId) }
+                        backClickAction:   () => { Hyprland.dispatch("togglespecialworkspace scratchpad") }
 
                         contentItem: Item {
                             anchors.centerIn: parent
@@ -382,10 +422,10 @@ Item {
                                     verticalCenter:   root.vertical ? parent.verticalCenter : undefined
                                 }
                                 Repeater {
-                                    model: Math.min(slotItem.appEntry?.toplevels?.length ?? 0, 3)
+                                    model: Math.min(slotItem.appToplevels.length, 3)
                                     delegate: Rectangle {
                                         required property int index
-                                        readonly property int topCount: slotItem.appEntry?.toplevels?.length ?? 0
+                                        readonly property int topCount: slotItem.appToplevels.length
                                         readonly property bool isSingleActive: slotItem.appActive && topCount === 1
 
                                         radius: Appearance.rounding.full
@@ -451,11 +491,21 @@ Item {
                     id: activeSlot
                     required property var modelData
 
-                    property bool appIsActive: modelData.toplevels.find(t => t.activated) !== undefined
+                    property var activeToplevels: {
+                        let list = modelData.toplevels ?? [];
+                        if (!root.alignToWorkspace) return list;
+                        return list.filter(t => {
+                            let win = HyprlandData.windowList.find(w => w.address === t.address || w.title === t.title);
+                            return win && win.workspace && win.workspace.id === root.activeWsId;
+                        });
+                    }
+                    property bool appIsActive: activeToplevels.find(t => t.activated) !== undefined
+                    readonly property bool isScratchpadApp: root.scratchpadOpen && TaskbarApps.normalizeAppId(modelData.appId) === root.scratchpadAppId
                     property int  _lastFocused: -1
 
                     width:  root.btnSize
                     height: root.btnSize
+                    opacity: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.25) : 1.0
 
                     RippleButton {
                         anchors.fill: parent
@@ -473,6 +523,9 @@ Item {
                         }
                         altAction: () => {
                             TaskbarApps.togglePin(activeSlot.modelData.appId)
+                        }
+                        backClickAction: () => {
+                            Hyprland.dispatch("togglespecialworkspace scratchpad")
                         }
 
                         contentItem: Item {
@@ -514,10 +567,10 @@ Item {
                                     verticalCenter:   root.vertical ? parent.verticalCenter : undefined
                                 }
                                 Repeater {
-                                    model: Math.min(activeSlot.modelData.toplevels.length, 3)
+                                    model: Math.min(activeSlot.activeToplevels.length, 3)
                                     delegate: Rectangle {
                                         required property int index
-                                        readonly property int topCount: activeSlot.modelData.toplevels.length
+                                        readonly property int topCount: activeSlot.activeToplevels.length
                                         readonly property bool isSingleActive: activeSlot.appIsActive && topCount === 1
 
                                         radius: Appearance.rounding.full

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
@@ -46,9 +46,35 @@ Item {
     readonly property real maxWindowPreviewWidth: 300
     readonly property real windowControlsHeight: 30
     readonly property bool isVertical: root.vertical
-    readonly property string dockEffectivePosition: {
-        if (vertical) return (Config.options?.bar?.left ?? false) ? "left" : "right";
-        return (Config.options?.bar?.bottom ?? false) ? "bottom" : "top";
+    property Item hoveredSlot: null
+    readonly property bool enableMacOsMagnification: Config.options?.dockToPanel?.enableMacOsMagnification ?? false
+    readonly property int magTransformOrigin: {
+        let pos = root.dockEffectivePosition;
+        if (pos === "top") return Item.Top;
+        if (pos === "bottom") return Item.Bottom;
+        if (pos === "left") return Item.Left;
+        if (pos === "right") return Item.Right;
+        return Item.Center;
+    }
+
+    readonly property real macOsMagnificationScale: Config.options?.dockToPanel?.macOsMagnificationScale ?? 1.6
+
+    function _getSlotMagScale(targetSlot) {
+        if (!enableMacOsMagnification || !buttonHovered || !hoveredSlot) return 1.0;
+        let maxScale = macOsMagnificationScale;
+        if (targetSlot === hoveredSlot) return maxScale;
+        let children = [];
+        for (let i = 0; i < flow.children.length; i++) {
+            let child = flow.children[i];
+            if (child && child.isAppSlot) children.push(child);
+        }
+        let myIdx = children.indexOf(targetSlot);
+        let hvdIdx = children.indexOf(hoveredSlot);
+        if (myIdx < 0 || hvdIdx < 0) return 1.0;
+        let dist = Math.abs(myIdx - hvdIdx);
+        if (dist === 1) return 1.0 + (maxScale - 1.0) * 0.45;
+        if (dist === 2) return 1.0 + (maxScale - 1.0) * 0.10;
+        return 1.0;
     }
 
     Timer {
@@ -56,6 +82,7 @@ Item {
         interval: 250
         onTriggered: {
             root.buttonHovered = false;
+            root.hoveredSlot = null;
         }
     }
 
@@ -341,9 +368,14 @@ Item {
                         return 0
                     }
 
-                    z: isDragged ? 100 : 0
+                    readonly property bool isAppSlot: true
+                    readonly property real magScale: root._getSlotMagScale(slotItem)
+                    readonly property real baseScale: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.85) : (isDragged ? 1.05 : 1.0)
                     opacity: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.35) : (isDragged ? 0.85 : 1.0)
-                    scale: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.85) : (isDragged ? 1.05 : 1.0)
+                    scale: baseScale
+
+                    width:  root.btnSize
+                    height: root.btnSize
 
                     Behavior on opacity {
                         enabled: !root._suppressTranslateAnim
@@ -383,10 +415,6 @@ Item {
                         }
                     }
 
-                    width:  root.btnSize
-                    height: root.btnSize
-
-
                     // ── DragHandler ──────────────────────────────────────────
                     DragHandler {
                         id: dragHandler
@@ -417,13 +445,40 @@ Item {
 
                     // ── Main button ──────────────────────────────────────────
                     RippleButton {
-                        anchors.fill: parent
+                        id: mainBtn
+                        width:  root.vertical ? Math.round(root.btnSize * slotItem.magScale) : parent.width
+                        height: root.vertical ? parent.height : Math.round(root.btnSize * slotItem.magScale)
+                        z: slotItem.isDragged ? 100 : Math.round(slotItem.magScale * 10)
+
+                        anchors.top:    (!root.vertical && root.dockEffectivePosition === "top")    ? parent.top    : undefined
+                        anchors.bottom: (!root.vertical && root.dockEffectivePosition === "bottom") ? parent.bottom : undefined
+                        anchors.left:   (root.vertical  && root.dockEffectivePosition === "left")   ? parent.left   : undefined
+                        anchors.right:  (root.vertical  && root.dockEffectivePosition === "right")  ? parent.right  : undefined
+
                         buttonRadius: Appearance.rounding.small
                         hoverEnabled: true
+                        colBackgroundHover: root.enableMacOsMagnification ? "transparent" : (Appearance?.colors.colLayer1Hover ?? "#E5DFED")
+                        colBackgroundActive: root.enableMacOsMagnification ? "transparent" : (Appearance?.colors.colLayer1Active ?? colBackgroundHover)
+
+                        Behavior on width {
+                            NumberAnimation {
+                                duration: Appearance.animation.elementMoveFast.duration
+                                easing.type: Appearance.animation.elementMoveFast.type
+                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                            }
+                        }
+                        Behavior on height {
+                            NumberAnimation {
+                                duration: Appearance.animation.elementMoveFast.duration
+                                easing.type: Appearance.animation.elementMoveFast.type
+                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                            }
+                        }
 
                         enteredAction: () => {
                             if (root.suppressHover || root.dragging) return;
                             hoverGraceTimer.stop();
+                            root.hoveredSlot = slotItem;
                             root.lastHoveredButton = slotItem;
                             root.buttonHovered = true;
                         }
@@ -457,14 +512,36 @@ Item {
                         }
 
                         contentItem: Item {
-                            anchors.centerIn: parent
+                            anchors.fill: parent
 
                             IconImage {
                                 id: pinnedIcon
-                                anchors.centerIn: parent
                                 source: Quickshell.iconPath(
                                     AppSearch.guessIcon(slotItem.appId), "image-missing")
-                                implicitSize: root.iconSize
+                                implicitSize: Math.round(root.iconSize * slotItem.magScale)
+
+                                anchors.top: (!root.vertical && root.dockEffectivePosition === "top") ? parent.top : undefined
+                                anchors.bottom: (!root.vertical && root.dockEffectivePosition === "bottom") ? parent.bottom : undefined
+                                anchors.left: (root.vertical && root.dockEffectivePosition === "left") ? parent.left : undefined
+                                anchors.right: (root.vertical && root.dockEffectivePosition === "right") ? parent.right : undefined
+
+                                anchors.topMargin: (!root.vertical && root.dockEffectivePosition === "top") ? Math.round((root.btnSize - root.iconSize) / 2) : 0
+                                anchors.bottomMargin: (!root.vertical && root.dockEffectivePosition === "bottom") ? Math.round((root.btnSize - root.iconSize) / 2) : 0
+                                anchors.leftMargin: (root.vertical && root.dockEffectivePosition === "left") ? Math.round((root.btnSize - root.iconSize) / 2) : 0
+                                anchors.rightMargin: (root.vertical && root.dockEffectivePosition === "right") ? Math.round((root.btnSize - root.iconSize) / 2) : 0
+
+                                anchors.horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
+                                anchors.verticalCenter: !root.vertical ? (
+                                    (root.dockEffectivePosition === "top" || root.dockEffectivePosition === "bottom") ? undefined : parent.verticalCenter
+                                ) : undefined
+
+                                Behavior on implicitSize {
+                                    NumberAnimation {
+                                        duration: Appearance.animation.elementMoveFast.duration
+                                        easing.type: Appearance.animation.elementMoveFast.type
+                                        easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                    }
+                                }
                             }
 
                             Loader {
@@ -572,10 +649,14 @@ Item {
                     readonly property bool hovered: root.lastHoveredButton === activeSlot && root.buttonHovered
                     property int  _lastFocused: -1
 
+                    readonly property bool isAppSlot: true
+                    readonly property real magScale: root._getSlotMagScale(activeSlot)
+                    readonly property real baseScale: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.85) : 1.0
+                    opacity: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.35) : 1.0
+                    scale: baseScale
+
                     width:  root.btnSize
                     height: root.btnSize
-                    opacity: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.35) : 1.0
-                    scale: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.85) : 1.0
 
                     Behavior on opacity {
                         NumberAnimation {
@@ -593,13 +674,40 @@ Item {
                     }
 
                     RippleButton {
-                        anchors.fill: parent
+                        id: activeBtn
+                        width:  root.vertical ? Math.round(root.btnSize * activeSlot.magScale) : parent.width
+                        height: root.vertical ? parent.height : Math.round(root.btnSize * activeSlot.magScale)
+                        z: Math.round(activeSlot.magScale * 10)
+
+                        anchors.top:    (!root.vertical && root.dockEffectivePosition === "top")    ? parent.top    : undefined
+                        anchors.bottom: (!root.vertical && root.dockEffectivePosition === "bottom") ? parent.bottom : undefined
+                        anchors.left:   (root.vertical  && root.dockEffectivePosition === "left")   ? parent.left   : undefined
+                        anchors.right:  (root.vertical  && root.dockEffectivePosition === "right")  ? parent.right  : undefined
+
                         buttonRadius: Appearance.rounding.small
                         hoverEnabled: true
+                        colBackgroundHover: root.enableMacOsMagnification ? "transparent" : (Appearance?.colors.colLayer1Hover ?? "#E5DFED")
+                        colBackgroundActive: root.enableMacOsMagnification ? "transparent" : (Appearance?.colors.colLayer1Active ?? colBackgroundHover)
+
+                        Behavior on width {
+                            NumberAnimation {
+                                duration: Appearance.animation.elementMoveFast.duration
+                                easing.type: Appearance.animation.elementMoveFast.type
+                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                            }
+                        }
+                        Behavior on height {
+                            NumberAnimation {
+                                duration: Appearance.animation.elementMoveFast.duration
+                                easing.type: Appearance.animation.elementMoveFast.type
+                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                            }
+                        }
 
                         enteredAction: () => {
                             if (root.suppressHover || root.dragging) return;
                             hoverGraceTimer.stop();
+                            root.hoveredSlot = activeSlot;
                             root.lastHoveredButton = activeSlot;
                             root.buttonHovered = true;
                         }
@@ -632,14 +740,36 @@ Item {
                         }
 
                         contentItem: Item {
-                            anchors.centerIn: parent
+                            anchors.fill: parent
 
                             IconImage {
                                 id: activeIcon
-                                anchors.centerIn: parent
                                 source: Quickshell.iconPath(
                                     AppSearch.guessIcon(activeSlot.modelData.appId), "image-missing")
-                                implicitSize: root.iconSize
+                                implicitSize: Math.round(root.iconSize * activeSlot.magScale)
+
+                                anchors.top: (!root.vertical && root.dockEffectivePosition === "top") ? parent.top : undefined
+                                anchors.bottom: (!root.vertical && root.dockEffectivePosition === "bottom") ? parent.bottom : undefined
+                                anchors.left: (root.vertical && root.dockEffectivePosition === "left") ? parent.left : undefined
+                                anchors.right: (root.vertical && root.dockEffectivePosition === "right") ? parent.right : undefined
+
+                                anchors.topMargin: (!root.vertical && root.dockEffectivePosition === "top") ? Math.round((root.btnSize - root.iconSize) / 2) : 0
+                                anchors.bottomMargin: (!root.vertical && root.dockEffectivePosition === "bottom") ? Math.round((root.btnSize - root.iconSize) / 2) : 0
+                                anchors.leftMargin: (root.vertical && root.dockEffectivePosition === "left") ? Math.round((root.btnSize - root.iconSize) / 2) : 0
+                                anchors.rightMargin: (root.vertical && root.dockEffectivePosition === "right") ? Math.round((root.btnSize - root.iconSize) / 2) : 0
+
+                                anchors.horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
+                                anchors.verticalCenter: !root.vertical ? (
+                                    (root.dockEffectivePosition === "top" || root.dockEffectivePosition === "bottom") ? undefined : parent.verticalCenter
+                                ) : undefined
+
+                                Behavior on implicitSize {
+                                    NumberAnimation {
+                                        duration: Appearance.animation.elementMoveFast.duration
+                                        easing.type: Appearance.animation.elementMoveFast.type
+                                        easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                    }
+                                }
                             }
 
                             Loader {

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
@@ -12,6 +12,8 @@ import Quickshell
 import Quickshell.Widgets
 import Quickshell.Hyprland
 
+import "../../../dock/widgets"
+
 Item {
     id: root
 
@@ -32,6 +34,20 @@ Item {
     readonly property bool scratchpadOpen: !!(currentHyprlandMonitorData && currentHyprlandMonitorData.specialWorkspace && currentHyprlandMonitorData.specialWorkspace.name !== "")
     readonly property var scratchpadWin: scratchpadOpen ? HyprlandData.windowList.find(w => w.workspace && w.workspace.id === currentHyprlandMonitorData.specialWorkspace.id) : null
     readonly property string scratchpadAppId: scratchpadWin ? TaskbarApps.normalizeAppId(scratchpadWin.class) : ""
+
+    // Hover, Tooltip and Preview state
+    property Item lastHoveredButton: null
+    property bool buttonHovered: false
+    property bool suppressHover: false
+    readonly property bool anyContextMenuOpen: false
+    readonly property real maxWindowPreviewHeight: 200
+    readonly property real maxWindowPreviewWidth: 300
+    readonly property real windowControlsHeight: 30
+    readonly property bool isVertical: root.vertical
+    readonly property string dockEffectivePosition: {
+        if (vertical) return (Config.options?.bar?.left ?? false) ? "left" : "right";
+        return (Config.options?.bar?.bottom ?? true) ? "bottom" : "top";
+    }
 
     // Helper to find lowest workspace ID for an app
     function _getAppMinWorkspace(appId) {
@@ -280,11 +296,26 @@ Item {
 
                     property string appId:        root._workOrder[index] ?? ""
                     property var    appEntry:     TaskbarApps.apps.find(a => a.appId === appId) ?? null
+                    property var    appToplevel:  appEntry
                     property var    appToplevels: appEntry?.toplevels ?? []
                     property var    deskEntry:    DesktopEntries.heuristicLookup(appId)
+                    property string appTitle:     deskEntry?.name ?? appId
                     property bool   appActive:    appToplevels.find(t => t.activated) !== undefined
                     readonly property bool isScratchpadApp: root.scratchpadOpen && TaskbarApps.normalizeAppId(appId) === root.scratchpadAppId
                     property int    _lastFocused: -1
+
+                    HoverHandler {
+                        id: slotHoverHandler
+                        enabled: !root.dragging
+                        onHoveredChanged: {
+                            if (hovered) {
+                                root.lastHoveredButton = slotItem;
+                                root.buttonHovered = true;
+                            } else if (root.lastHoveredButton === slotItem) {
+                                root.buttonHovered = false;
+                            }
+                        }
+                    }
 
                     // ── Animation properties (with clamping) ──────────────
                     readonly property bool isDragged: root.dragging && index === root.dragSourceIndex
@@ -509,9 +540,24 @@ Item {
                     required property var modelData
 
                     property var activeToplevels: modelData.toplevels ?? []
+                    property var appToplevel: modelData
+                    property string appTitle: DesktopEntries.heuristicLookup(modelData.appId)?.name ?? modelData.appId
                     property bool appIsActive: activeToplevels.find(t => t.activated) !== undefined
                     readonly property bool isScratchpadApp: root.scratchpadOpen && TaskbarApps.normalizeAppId(modelData.appId) === root.scratchpadAppId
                     property int  _lastFocused: -1
+
+                    HoverHandler {
+                        id: activeHoverHandler
+                        enabled: !root.dragging
+                        onHoveredChanged: {
+                            if (hovered) {
+                                root.lastHoveredButton = activeSlot;
+                                root.buttonHovered = true;
+                            } else if (root.lastHoveredButton === activeSlot) {
+                                root.buttonHovered = false;
+                            }
+                        }
+                    }
 
                     width:  root.btnSize
                     height: root.btnSize
@@ -638,6 +684,28 @@ Item {
                     }
                 }
             }
+        }
+    }
+
+    // ── Tooltip and Window Preview ───────────────────────────────────────
+    Loader {
+        id: tooltipLoader
+        active: Config.options?.dockToPanel?.enableTooltip ?? true
+        sourceComponent: DockTooltip {
+            parentItem: root.lastHoveredButton
+            text: root.lastHoveredButton?.appTitle ?? ""
+            showTooltip: root.buttonHovered && !root.scratchpadOpen && text !== ""
+            dockPosition: root.dockEffectivePosition === "top" ? "bottom" : (root.dockEffectivePosition === "bottom" ? "top" : (root.dockEffectivePosition === "left" ? "right" : "left"))
+        }
+    }
+
+    Loader {
+        id: previewPopupLoader
+        active: Config.options?.dockToPanel?.enablePreview ?? true
+        sourceComponent: DockPreviewPopup {
+            dockRoot: root
+            dockWindow: root.QsWindow.window
+            appTopLevel: root.lastHoveredButton?.appToplevel
         }
     }
 }

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
@@ -33,16 +33,35 @@ Item {
     readonly property var scratchpadWin: scratchpadOpen ? HyprlandData.windowList.find(w => w.workspace && w.workspace.id === currentHyprlandMonitorData.specialWorkspace.id) : null
     readonly property string scratchpadAppId: scratchpadWin ? TaskbarApps.normalizeAppId(scratchpadWin.class) : ""
 
-    property var activeUnpinned: TaskbarApps.apps.filter(a => {
-        if (a.pinned || a.appId === "SEPARATOR" || a.toplevels.length === 0) return false;
-        if (!root.alignToWorkspace) return true;
-        return a.toplevels.some(t => {
+    // Helper to find lowest workspace ID for an app
+    function _getAppMinWorkspace(appId) {
+        let entry = TaskbarApps.apps.find(a => a.appId === appId);
+        if (!entry || !entry.toplevels || entry.toplevels.length === 0) return 999;
+        let minWs = 999;
+        for (let t of entry.toplevels) {
             let win = HyprlandData.windowList.find(w => w.address === t.address || w.title === t.title);
-            return win && win.workspace && win.workspace.id === root.activeWsId;
-        });
-    })
+            if (win && win.workspace && win.workspace.id > 0) {
+                if (win.workspace.id < minWs) minWs = win.workspace.id;
+            }
+        }
+        return minWs;
+    }
+
+    property var activeUnpinned: {
+        let list = TaskbarApps.apps.filter(a => !a.pinned && a.appId !== "SEPARATOR" && a.toplevels.length > 0);
+        if (root.alignToWorkspace) {
+            list.sort((a, b) => root._getAppMinWorkspace(a.appId) - root._getAppMinWorkspace(b.appId));
+        }
+        return list;
+    }
     property bool showSeparator: _workOrder.length > 0 && activeUnpinned.length > 0
-    property var  _workOrder:            pinnedApps.slice()
+    property var  _workOrder: {
+        let list = pinnedApps.slice();
+        if (root.alignToWorkspace) {
+            list.sort((a, b) => root._getAppMinWorkspace(a) - root._getAppMinWorkspace(b));
+        }
+        return list;
+    }
     property bool _dragging:             false
 
     // ── Drag animation state ──────────────────────────────────────────────
@@ -234,10 +253,13 @@ Item {
             acceptedButtons: Qt.NoButton
             onWheel: event => {
                 let delta = event.angleDelta.y !== 0 ? event.angleDelta.y : event.angleDelta.x;
-                if (delta > 0)
-                    Hyprland.dispatch("workspace", "e-1");
-                else if (delta < 0)
-                    Hyprland.dispatch("workspace", "e+1");
+                if (delta > 0) {
+                    let target = Math.max(1, root.activeWsId - 1);
+                    Hyprland.dispatch("hl.dsp.focus({ workspace = " + target + " })");
+                } else if (delta < 0) {
+                    let target = root.activeWsId + 1;
+                    Hyprland.dispatch("hl.dsp.focus({ workspace = " + target + " })");
+                }
             }
         }
 
@@ -258,14 +280,7 @@ Item {
 
                     property string appId:        root._workOrder[index] ?? ""
                     property var    appEntry:     TaskbarApps.apps.find(a => a.appId === appId) ?? null
-                    property var    appToplevels: {
-                        let list = appEntry?.toplevels ?? [];
-                        if (!root.alignToWorkspace) return list;
-                        return list.filter(t => {
-                            let win = HyprlandData.windowList.find(w => w.address === t.address || w.title === t.title);
-                            return win && win.workspace && win.workspace.id === root.activeWsId;
-                        });
-                    }
+                    property var    appToplevels: appEntry?.toplevels ?? []
                     property var    deskEntry:    DesktopEntries.heuristicLookup(appId)
                     property bool   appActive:    appToplevels.find(t => t.activated) !== undefined
                     readonly property bool isScratchpadApp: root.scratchpadOpen && TaskbarApps.normalizeAppId(appId) === root.scratchpadAppId
@@ -339,6 +354,7 @@ Item {
                     // ── DragHandler ──────────────────────────────────────────
                     DragHandler {
                         id: dragHandler
+                        enabled: !root.alignToWorkspace
                         target: null
                         grabPermissions: PointerHandler.CanTakeOverFromAnything
 
@@ -382,7 +398,7 @@ Item {
                         }
                         middleClickAction: () => { slotItem.deskEntry?.execute() }
                         altAction:         () => { TaskbarApps.togglePin(slotItem.appId) }
-                        backClickAction:   () => { Hyprland.dispatch("togglespecialworkspace", "scratchpad") }
+                        backClickAction:   () => { Hyprland.dispatch("hl.dsp.workspace.toggle_special('special')") }
 
                         contentItem: Item {
                             anchors.centerIn: parent
@@ -492,14 +508,7 @@ Item {
                     id: activeSlot
                     required property var modelData
 
-                    property var activeToplevels: {
-                        let list = modelData.toplevels ?? [];
-                        if (!root.alignToWorkspace) return list;
-                        return list.filter(t => {
-                            let win = HyprlandData.windowList.find(w => w.address === t.address || w.title === t.title);
-                            return win && win.workspace && win.workspace.id === root.activeWsId;
-                        });
-                    }
+                    property var activeToplevels: modelData.toplevels ?? []
                     property bool appIsActive: activeToplevels.find(t => t.activated) !== undefined
                     readonly property bool isScratchpadApp: root.scratchpadOpen && TaskbarApps.normalizeAppId(modelData.appId) === root.scratchpadAppId
                     property int  _lastFocused: -1
@@ -542,7 +551,7 @@ Item {
                             TaskbarApps.togglePin(activeSlot.modelData.appId)
                         }
                         backClickAction: () => {
-                            Hyprland.dispatch("togglespecialworkspace", "scratchpad")
+                            Hyprland.dispatch("hl.dsp.workspace.toggle_special('special')")
                         }
 
                         contentItem: Item {

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
@@ -174,18 +174,6 @@ Item {
         ? pill.implicitHeight
         : Appearance.sizes.barHeight
 
-    function swapSlots(from, to) {
-        if (from === to) return
-        if (from < 0 || from >= _workOrder.length) return
-        if (to   < 0 || to   >= _workOrder.length) return
-        let arr = _workOrder.slice()
-        let tmp = arr[from]; arr[from] = arr[to]; arr[to] = tmp
-        _workOrder = arr
-    }
-
-    function commitOrder() {
-        Config.options.dock.pinnedApps = _workOrder.slice()
-    }
 
     Rectangle {
         id: pill
@@ -208,10 +196,18 @@ Item {
                     : Appearance.sizes.barHeight
 
         Behavior on implicitWidth {
-            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            NumberAnimation {
+                duration: Appearance.animation.elementMoveFast.duration
+                easing.type: Appearance.animation.elementMoveFast.type
+                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+            }
         }
         Behavior on implicitHeight {
-            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            NumberAnimation {
+                duration: Appearance.animation.elementMoveFast.duration
+                easing.type: Appearance.animation.elementMoveFast.type
+                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+            }
         }
 
         Flow {
@@ -260,11 +256,19 @@ Item {
 
                     Behavior on opacity {
                         enabled: !root._suppressTranslateAnim
-                        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                        NumberAnimation {
+                            duration: Appearance.animation.elementMoveFast.duration
+                            easing.type: Appearance.animation.elementMoveFast.type
+                            easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                        }
                     }
                     Behavior on scale {
                         enabled: !root._suppressTranslateAnim
-                        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                        NumberAnimation {
+                            duration: Appearance.animation.elementMoveFast.duration
+                            easing.type: Appearance.animation.elementMoveFast.type
+                            easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                        }
                     }
 
                     transform: Translate {
@@ -272,23 +276,25 @@ Item {
                         y: root.vertical ? slotItem.dragTranslate : 0
                         Behavior on x {
                             enabled: !slotItem.isDragged && !root._suppressTranslateAnim
-                            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                            NumberAnimation {
+                                duration: Appearance.animation.elementMoveFast.duration
+                                easing.type: Appearance.animation.elementMoveFast.type
+                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                            }
                         }
                         Behavior on y {
                             enabled: !slotItem.isDragged && !root._suppressTranslateAnim
-                            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                            NumberAnimation {
+                                duration: Appearance.animation.elementMoveFast.duration
+                                easing.type: Appearance.animation.elementMoveFast.type
+                                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                            }
                         }
                     }
 
                     width:  root.btnSize
                     height: root.btnSize
 
-                    Connections {
-                        target: DesktopEntries
-                        function onApplicationsChanged() {
-                            slotItem.deskEntry = DesktopEntries.heuristicLookup(slotItem.appId)
-                        }
-                    }
 
                     // ── DragHandler ──────────────────────────────────────────
                     DragHandler {
@@ -349,7 +355,7 @@ Item {
                             }
 
                             Loader {
-                                active: Config.options.dock.monochromeIcons
+                                active: Config.options?.dock?.monochromeIcons ?? false
                                 anchors.fill: pinnedIcon
                                 sourceComponent: Item {
                                     Desaturate {
@@ -414,7 +420,7 @@ Item {
             // ── 3. ACTIVE UNPINNED APPS ───────────────────────────────────
             Repeater {
                 id: activeRepeater
-                model: ScriptModel { values: root.activeUnpinned }
+                model: root.activeUnpinned
 
                 delegate: Item {
                     id: activeSlot
@@ -456,7 +462,7 @@ Item {
                             }
 
                             Loader {
-                                active: Config.options.dock.monochromeIcons
+                                active: Config.options?.dock?.monochromeIcons ?? false
                                 anchors.fill: activeIcon
                                 sourceComponent: Item {
                                     Desaturate {

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
@@ -1,0 +1,508 @@
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Effects
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
+import Quickshell
+import Quickshell.Widgets
+import Quickshell.Hyprland
+
+Item {
+    id: root
+
+    property real iconSize:      Config.options.dockToPanel.iconSize
+    property real btnSize:       iconSize + 5
+    property real btnSpacing:    Config.options.dockToPanel.buttonSpacing
+    property bool vertical:    Config.options.bar.vertical
+    property bool isMaterial:  Config.options.bar.cornerStyle === 3
+    property var pinnedApps: Config.options?.dock.pinnedApps ?? []
+    property var activeUnpinned: TaskbarApps.apps.filter(
+        a => !a.pinned && a.appId !== "SEPARATOR" && a.toplevels.length > 0
+    )
+    property bool showSeparator: _workOrder.length > 0 && activeUnpinned.length > 0
+    property var  _workOrder:            pinnedApps.slice()
+    property bool _dragging:             false
+
+    // ── Drag animation state ──────────────────────────────────────────────
+    property bool dragging: false
+    property bool _suppressTranslateAnim: false
+    property int dragSourceIndex: -1
+    property int _dragTargetIndex: -1
+    property real dragCursorX: 0
+    property real dragStartCursorX: 0
+    property real slotWidth: root.btnSize + root.btnSpacing
+
+    Layout.fillHeight: !vertical
+    Layout.fillWidth: vertical
+
+    function _getPinnedItemWrapper(index) {
+        return pinnedRepeater.itemAt(index)
+    }
+
+    function _getPinnedItemWidth(index) {
+        var wrapper = _getPinnedItemWrapper(index)
+        return wrapper ? (root.vertical ? wrapper.height : wrapper.width) : root.btnSize
+    }
+
+    function _getMaxDragOffset(index) {
+        var count = _workOrder.length
+        if (count <= 1) return { left: 0, right: 0 }
+        var left = 0, right = 0
+        for (var i = 0; i < count; i++) {
+            var w = _getPinnedItemWidth(i) + root.btnSpacing
+            if (i < index) left += w
+            else if (i > index) right += w
+        }
+        return { left: -left, right: right }
+    }
+
+    function _recomputeDragTarget() {
+        if (!dragging) {
+            _dragTargetIndex = dragSourceIndex
+            return
+        }
+
+        var count = _workOrder.length
+        if (count <= 1) {
+            _dragTargetIndex = dragSourceIndex
+            return
+        }
+
+        var delta = dragCursorX - dragStartCursorX
+
+        // dragged item center
+        var draggedCenter = delta
+
+        var target = dragSourceIndex
+
+        if (delta > 0) {
+            // moving right/down
+            var pos = 0
+            for (var i = dragSourceIndex + 1; i < count; ++i) {
+                pos += (_getPinnedItemWidth(i - 1) + root.btnSpacing) / 2
+                pos += (_getPinnedItemWidth(i) + root.btnSpacing) / 2
+
+                if (draggedCenter >= pos)
+                    target = i
+                else
+                    break
+            }
+        } else if (delta < 0) {
+            var pos = 0
+            for (var i = dragSourceIndex - 1; i >= 0; --i) {
+                pos -= (_getPinnedItemWidth(i + 1) + root.btnSpacing) / 2
+                pos -= (_getPinnedItemWidth(i) + root.btnSpacing) / 2
+
+                if (draggedCenter <= pos)
+                    target = i
+                else
+                    break
+            }
+        }
+
+        _dragTargetIndex = target
+    }
+
+    function _startPinnedItemDrag(index) {
+        _suppressTranslateAnim = true
+        dragSourceIndex = index
+        _dragTargetIndex = index
+        slotWidth = root.btnSize + root.btnSpacing
+        dragStartCursorX = 0
+        dragCursorX = 0
+        dragging = true
+        Qt.callLater(function() { _suppressTranslateAnim = false })
+    }
+
+    // ── FIXED: move instead of swap ──────────────────────────────────────
+    function _endPinnedItemDrag() {
+        _suppressTranslateAnim = true
+
+        var src = dragSourceIndex
+        var tgt = _dragTargetIndex
+
+        if (dragging &&
+            src >= 0 &&
+            tgt >= 0 &&
+            src < _workOrder.length &&
+            tgt < _workOrder.length &&
+            src !== tgt) {
+
+            var arr = _workOrder.slice()
+
+            var item = arr[src]
+            arr.splice(src, 1)
+            arr.splice(tgt, 0, item)
+
+            _workOrder = arr
+            Config.options.dock.pinnedApps = arr
+        }
+
+        dragging = false
+        dragSourceIndex = -1
+        _dragTargetIndex = -1
+        dragCursorX = 0
+        dragStartCursorX = 0
+
+        Qt.callLater(function() {
+            _suppressTranslateAnim = false
+        })
+    }
+
+    function _cancelPinnedDrag() {
+        _suppressTranslateAnim = true
+        dragging = false
+        dragSourceIndex = -1
+        _dragTargetIndex = -1
+        Qt.callLater(function() { _suppressTranslateAnim = false })
+    }
+
+    onPinnedAppsChanged: {
+        if (!_dragging)
+            _workOrder = pinnedApps.slice()
+    }
+
+    implicitWidth:  vertical
+        ? (isMaterial ? Appearance.sizes.verticalBarWidth : Appearance.sizes.verticalBarWidth - 10)
+        : pill.implicitWidth
+    implicitHeight: vertical
+        ? pill.implicitHeight
+        : Appearance.sizes.barHeight
+
+    function swapSlots(from, to) {
+        if (from === to) return
+        if (from < 0 || from >= _workOrder.length) return
+        if (to   < 0 || to   >= _workOrder.length) return
+        let arr = _workOrder.slice()
+        let tmp = arr[from]; arr[from] = arr[to]; arr[to] = tmp
+        _workOrder = arr
+    }
+
+    function commitOrder() {
+        Config.options.dock.pinnedApps = _workOrder.slice()
+    }
+
+    Rectangle {
+        id: pill
+        anchors.centerIn: parent
+        color: "transparent"
+        radius: Appearance.rounding.full
+
+        implicitWidth: root.isMaterial && !root.vertical
+            ? flow.implicitWidth + 10
+            : root.vertical
+                ? (root.isMaterial ? 32 : Appearance.sizes.verticalBarWidth - 10)
+                : flow.implicitWidth + 4
+
+        implicitHeight: root.isMaterial && root.vertical
+            ? flow.implicitHeight + 10
+            : root.isMaterial
+                ? 32
+                : root.vertical
+                    ? flow.implicitHeight + 4
+                    : Appearance.sizes.barHeight
+
+        Behavior on implicitWidth {
+            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+        }
+        Behavior on implicitHeight {
+            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+        }
+
+        Flow {
+            id: flow
+            anchors.centerIn: parent
+            flow:    root.vertical ? Flow.TopToBottom : Flow.LeftToRight
+            spacing: root.btnSpacing
+
+            // ── 1. PINNED APPS ───────────────────────────────────────────
+            Repeater {
+                id: pinnedRepeater
+                model: root._workOrder.length
+
+                delegate: Item {
+                    id: slotItem
+                    required property int index
+
+                    property string appId:        root._workOrder[index] ?? ""
+                    property var    appEntry:     TaskbarApps.apps.find(a => a.appId === appId) ?? null
+                    property var    deskEntry:    DesktopEntries.heuristicLookup(appId)
+                    property bool   appActive:    appEntry?.toplevels?.find(t => t.activated) !== undefined
+                    property int    _lastFocused: -1
+
+                    // ── Animation properties (with clamping) ──────────────
+                    readonly property bool isDragged: root.dragging && index === root.dragSourceIndex
+                    readonly property real dragTranslate: {
+                        if (!root.dragging) return 0
+                        if (isDragged) {
+                            var raw = root.dragCursorX - root.dragStartCursorX
+                            var maxOff = root._getMaxDragOffset(index)
+                            var clamped = Math.max(maxOff.left, Math.min(maxOff.right, raw))
+                            return clamped
+                        }
+                        var src = root.dragSourceIndex
+                        var tgt = root._dragTargetIndex
+                        var idx = index
+                        var sw = root.slotWidth
+                        if (src < tgt && idx > src && idx <= tgt) return -sw
+                        if (src > tgt && idx >= tgt && idx < src) return sw
+                        return 0
+                    }
+
+                    z: isDragged ? 100 : 0
+                    opacity: isDragged ? 0.85 : 1
+                    scale: isDragged ? 1.05 : 1
+
+                    Behavior on opacity {
+                        enabled: !root._suppressTranslateAnim
+                        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                    }
+                    Behavior on scale {
+                        enabled: !root._suppressTranslateAnim
+                        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                    }
+
+                    transform: Translate {
+                        x: root.vertical ? 0 : slotItem.dragTranslate
+                        y: root.vertical ? slotItem.dragTranslate : 0
+                        Behavior on x {
+                            enabled: !slotItem.isDragged && !root._suppressTranslateAnim
+                            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                        }
+                        Behavior on y {
+                            enabled: !slotItem.isDragged && !root._suppressTranslateAnim
+                            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                        }
+                    }
+
+                    width:  root.btnSize
+                    height: root.btnSize
+
+                    Connections {
+                        target: DesktopEntries
+                        function onApplicationsChanged() {
+                            slotItem.deskEntry = DesktopEntries.heuristicLookup(slotItem.appId)
+                        }
+                    }
+
+                    // ── DragHandler ──────────────────────────────────────────
+                    DragHandler {
+                        id: dragHandler
+                        target: null
+                        grabPermissions: PointerHandler.CanTakeOverFromAnything
+
+                        onActiveChanged: {
+                            if (active) {
+                                root._startPinnedItemDrag(index)
+                                var pos = root.vertical ? centroid.scenePosition.y : centroid.scenePosition.x
+                                root.dragStartCursorX = pos
+                                root.dragCursorX = pos
+                            } else {
+                                if (root.dragging) {
+                                    root._endPinnedItemDrag()
+                                }
+                            }
+                        }
+
+                        onCentroidChanged: {
+                            if (!active || !root.dragging) return
+                            var pos = root.vertical ? centroid.scenePosition.y : centroid.scenePosition.x
+                            root.dragCursorX = pos
+                            root._recomputeDragTarget()
+                        }
+                    }
+
+                    // ── Main button ──────────────────────────────────────────
+                    RippleButton {
+                        anchors.fill: parent
+                        buttonRadius: Appearance.rounding.small
+                        hoverEnabled: true
+
+                        onClicked: {
+                            if (root.dragging) return
+                            const entry = slotItem.appEntry
+                            if (!entry || entry.toplevels.length === 0) {
+                                slotItem.deskEntry?.execute()
+                                return
+                            }
+                            const next = (slotItem._lastFocused + 1) % entry.toplevels.length
+                            slotItem._lastFocused = next
+                            entry.toplevels[next].activate()
+                        }
+                        middleClickAction: () => { slotItem.deskEntry?.execute() }
+                        altAction:         () => { TaskbarApps.togglePin(slotItem.appId) }
+
+                        contentItem: Item {
+                            anchors.centerIn: parent
+
+                            IconImage {
+                                id: pinnedIcon
+                                anchors.centerIn: parent
+                                source: Quickshell.iconPath(
+                                    AppSearch.guessIcon(slotItem.appId), "image-missing")
+                                implicitSize: root.iconSize
+                            }
+
+                            Loader {
+                                active: Config.options.dock.monochromeIcons
+                                anchors.fill: pinnedIcon
+                                sourceComponent: Item {
+                                    Desaturate {
+                                        id: desat; visible: false
+                                        anchors.fill: parent
+                                        source: pinnedIcon; desaturation: 0.8
+                                    }
+                                    ColorOverlay {
+                                        anchors.fill: desat; source: desat
+                                        color: ColorUtils.transparentize(Appearance.colors.colPrimary, Config.options.appearance.iconTintPercentage)
+                                    }
+                                }
+                            }
+
+                            Flow {
+                                flow: root.vertical ? Flow.TopToBottom : Flow.LeftToRight
+                                spacing: 2
+                                anchors {
+                                    left:   root.vertical ? pinnedIcon.right    : undefined
+                                    top:    root.vertical ? undefined            : pinnedIcon.bottom
+                                    leftMargin:  root.vertical ? 1 : 0
+                                    topMargin:   root.vertical ? 0 : 1
+                                    horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
+                                    verticalCenter:   root.vertical ? parent.verticalCenter : undefined
+                                }
+                                Repeater {
+                                    model: Math.min(slotItem.appEntry?.toplevels?.length ?? 0, 3)
+                                    delegate: Rectangle {
+                                        required property int index
+                                        radius: Appearance.rounding.full
+                                        implicitWidth:  root.vertical
+                                            ? 2
+                                            : (slotItem.appEntry?.toplevels?.length ?? 0) <= 3 ? 4 : 2
+                                        implicitHeight: root.vertical
+                                            ? ((slotItem.appEntry?.toplevels?.length ?? 0) <= 3 ? 4 : 2)
+                                            : 2
+                                        color: slotItem.appActive
+                                            ? Appearance.colors.colPrimary
+                                            : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.4)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── 2. SEPARATOR ─────────────────────────────────────────────
+            Item {
+                width:   root.vertical ? root.btnSize          : (root.showSeparator ? (1 + root.btnSpacing * 3) : 0)
+                height:  root.vertical ? (root.showSeparator ? (1 + root.btnSpacing * 3) : 0) : root.btnSize
+                visible: root.showSeparator
+
+                Rectangle {
+                    anchors.centerIn: parent
+                    width:  root.vertical ? Math.round(root.btnSize * 0.6) : 1
+                    height: root.vertical ? 1 : Math.round(root.btnSize * 0.6)
+                    color:  root.isMaterial ? Appearance.colors.colPrimary : Appearance.colors.colOutlineVariant
+                }
+            }
+
+            // ── 3. ACTIVE UNPINNED APPS ───────────────────────────────────
+            Repeater {
+                id: activeRepeater
+                model: ScriptModel { values: root.activeUnpinned }
+
+                delegate: Item {
+                    id: activeSlot
+                    required property var modelData
+
+                    property bool appIsActive: modelData.toplevels.find(t => t.activated) !== undefined
+                    property int  _lastFocused: -1
+
+                    width:  root.btnSize
+                    height: root.btnSize
+
+                    RippleButton {
+                        anchors.fill: parent
+                        buttonRadius: Appearance.rounding.small
+                        hoverEnabled: true
+
+                        onClicked: {
+                            if (activeSlot.modelData.toplevels.length === 0) return
+                            const next = (activeSlot._lastFocused + 1) % activeSlot.modelData.toplevels.length
+                            activeSlot._lastFocused = next
+                            activeSlot.modelData.toplevels[next].activate()
+                        }
+                        middleClickAction: () => {
+                            DesktopEntries.heuristicLookup(activeSlot.modelData.appId)?.execute()
+                        }
+                        altAction: () => {
+                            TaskbarApps.togglePin(activeSlot.modelData.appId)
+                        }
+
+                        contentItem: Item {
+                            anchors.centerIn: parent
+
+                            IconImage {
+                                id: activeIcon
+                                anchors.centerIn: parent
+                                source: Quickshell.iconPath(
+                                    AppSearch.guessIcon(activeSlot.modelData.appId), "image-missing")
+                                implicitSize: root.iconSize
+                            }
+
+                            Loader {
+                                active: Config.options.dock.monochromeIcons
+                                anchors.fill: activeIcon
+                                sourceComponent: Item {
+                                    Desaturate {
+                                        id: desat2; visible: false
+                                        anchors.fill: parent
+                                        source: activeIcon; desaturation: 0.8
+                                    }
+                                    ColorOverlay {
+                                        anchors.fill: desat2; source: desat2
+                                        color: ColorUtils.transparentize(Appearance.colors.colPrimary, Config.options.appearance.iconTintPercentage)
+                                    }
+                                }
+                            }
+
+                            Flow {
+                                flow: root.vertical ? Flow.TopToBottom : Flow.LeftToRight
+                                spacing: 2
+                                anchors {
+                                    left:   root.vertical ? activeIcon.right    : undefined
+                                    top:    root.vertical ? undefined            : activeIcon.bottom
+                                    leftMargin:  root.vertical ? 1 : 0
+                                    topMargin:   root.vertical ? 0 : 1
+                                    horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
+                                    verticalCenter:   root.vertical ? parent.verticalCenter : undefined
+                                }
+                                Repeater {
+                                    model: Math.min(activeSlot.modelData.toplevels.length, 3)
+                                    delegate: Rectangle {
+                                        required property int index
+                                        radius: Appearance.rounding.full
+                                        implicitWidth:  root.vertical
+                                            ? 2
+                                            : activeSlot.modelData.toplevels.length <= 3 ? 4 : 2
+                                        implicitHeight: root.vertical
+                                            ? (activeSlot.modelData.toplevels.length <= 3 ? 4 : 2)
+                                            : 2
+                                        color: activeSlot.appIsActive
+                                            ? Appearance.colors.colPrimary
+                                            : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.4)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
@@ -390,11 +390,11 @@ Item {
 
                                         radius: Appearance.rounding.full
                                         implicitWidth: root.vertical
-                                            ? 2
-                                            : (isSingleActive ? 12 : (topCount <= 3 ? 4 : 2))
+                                            ? 3
+                                            : (isSingleActive ? 14 : (topCount <= 3 ? 4 : 3))
                                         implicitHeight: root.vertical
-                                            ? (isSingleActive ? 12 : (topCount <= 3 ? 4 : 2))
-                                            : 2
+                                            ? (isSingleActive ? 14 : (topCount <= 3 ? 4 : 3))
+                                            : 3
                                         color: slotItem.appActive
                                             ? Appearance.colors.colPrimary
                                             : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.75)
@@ -522,14 +522,14 @@ Item {
 
                                         radius: Appearance.rounding.full
                                         implicitWidth: root.vertical
-                                            ? 2
-                                            : (isSingleActive ? 12 : (topCount <= 3 ? 4 : 2))
+                                            ? 3
+                                            : (isSingleActive ? 14 : (topCount <= 3 ? 4 : 3))
                                         implicitHeight: root.vertical
-                                            ? (isSingleActive ? 12 : (topCount <= 3 ? 4 : 2))
-                                            : 2
+                                            ? (isSingleActive ? 14 : (topCount <= 3 ? 4 : 3))
+                                            : 3
                                         color: activeSlot.appIsActive
                                             ? Appearance.colors.colPrimary
-                                            : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.75)
+                                            : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.45)
 
                                         Behavior on implicitWidth {
                                             NumberAnimation {

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
@@ -11,8 +11,8 @@ import Qt5Compat.GraphicalEffects
 import Quickshell
 import Quickshell.Widgets
 import Quickshell.Hyprland
-
-import "../../../dock/widgets"
+import Quickshell.Wayland
+import qs.modules.ii.bar.shared
 
 Item {
     id: root
@@ -37,8 +37,10 @@ Item {
 
     // Hover, Tooltip and Preview state
     property Item lastHoveredButton: null
+    property point hoveredButtonCenter: Qt.point(0, 0)
     property bool buttonHovered: false
     property bool suppressHover: false
+    property bool popupIsResizing: false
     readonly property bool anyContextMenuOpen: false
     readonly property real maxWindowPreviewHeight: 200
     readonly property real maxWindowPreviewWidth: 300
@@ -46,7 +48,22 @@ Item {
     readonly property bool isVertical: root.vertical
     readonly property string dockEffectivePosition: {
         if (vertical) return (Config.options?.bar?.left ?? false) ? "left" : "right";
-        return (Config.options?.bar?.bottom ?? true) ? "bottom" : "top";
+        return (Config.options?.bar?.bottom ?? false) ? "bottom" : "top";
+    }
+
+    Timer {
+        id: hoverGraceTimer
+        interval: 250
+        onTriggered: {
+            root.buttonHovered = false;
+        }
+    }
+
+    onLastHoveredButtonChanged: {
+        if (root.lastHoveredButton) {
+            let p = root.lastHoveredButton.mapToItem(null, root.lastHoveredButton.width / 2, root.lastHoveredButton.height / 2);
+            root.hoveredButtonCenter = p;
+        }
     }
 
     // Helper to find lowest workspace ID for an app
@@ -302,20 +319,8 @@ Item {
                     property string appTitle:     deskEntry?.name ?? appId
                     property bool   appActive:    appToplevels.find(t => t.activated) !== undefined
                     readonly property bool isScratchpadApp: root.scratchpadOpen && TaskbarApps.normalizeAppId(appId) === root.scratchpadAppId
+                    readonly property bool hovered: root.lastHoveredButton === slotItem && root.buttonHovered
                     property int    _lastFocused: -1
-
-                    HoverHandler {
-                        id: slotHoverHandler
-                        enabled: !root.dragging
-                        onHoveredChanged: {
-                            if (hovered) {
-                                root.lastHoveredButton = slotItem;
-                                root.buttonHovered = true;
-                            } else if (root.lastHoveredButton === slotItem) {
-                                root.buttonHovered = false;
-                            }
-                        }
-                    }
 
                     // ── Animation properties (with clamping) ──────────────
                     readonly property bool isDragged: root.dragging && index === root.dragSourceIndex
@@ -416,6 +421,17 @@ Item {
                         buttonRadius: Appearance.rounding.small
                         hoverEnabled: true
 
+                        enteredAction: () => {
+                            if (root.suppressHover || root.dragging) return;
+                            hoverGraceTimer.stop();
+                            root.lastHoveredButton = slotItem;
+                            root.buttonHovered = true;
+                        }
+                        exitedAction: () => {
+                            if (root.lastHoveredButton === slotItem)
+                                hoverGraceTimer.restart();
+                        }
+
                         onClicked: {
                             if (root.dragging) return
                             const entry = slotItem.appEntry
@@ -429,7 +445,16 @@ Item {
                         }
                         middleClickAction: () => { slotItem.deskEntry?.execute() }
                         altAction:         () => { TaskbarApps.togglePin(slotItem.appId) }
-                        backClickAction:   () => { Hyprland.dispatch("hl.dsp.workspace.toggle_special('special')") }
+                        backClickAction: () => {
+                            root.buttonHovered = false;
+                            root.lastHoveredButton = null;
+                            Hyprland.dispatch("hl.dsp.workspace.toggle_special('special')");
+                        }
+
+                        StyledToolTip {
+                            text: slotItem.appTitle
+                            extraVisibleCondition: (Config.options?.dockToPanel?.enableTooltip ?? true) && !(Config.options?.dockToPanel?.enablePreview ?? false)
+                        }
 
                         contentItem: Item {
                             anchors.centerIn: parent
@@ -544,20 +569,8 @@ Item {
                     property string appTitle: DesktopEntries.heuristicLookup(modelData.appId)?.name ?? modelData.appId
                     property bool appIsActive: activeToplevels.find(t => t.activated) !== undefined
                     readonly property bool isScratchpadApp: root.scratchpadOpen && TaskbarApps.normalizeAppId(modelData.appId) === root.scratchpadAppId
+                    readonly property bool hovered: root.lastHoveredButton === activeSlot && root.buttonHovered
                     property int  _lastFocused: -1
-
-                    HoverHandler {
-                        id: activeHoverHandler
-                        enabled: !root.dragging
-                        onHoveredChanged: {
-                            if (hovered) {
-                                root.lastHoveredButton = activeSlot;
-                                root.buttonHovered = true;
-                            } else if (root.lastHoveredButton === activeSlot) {
-                                root.buttonHovered = false;
-                            }
-                        }
-                    }
 
                     width:  root.btnSize
                     height: root.btnSize
@@ -584,6 +597,17 @@ Item {
                         buttonRadius: Appearance.rounding.small
                         hoverEnabled: true
 
+                        enteredAction: () => {
+                            if (root.suppressHover || root.dragging) return;
+                            hoverGraceTimer.stop();
+                            root.lastHoveredButton = activeSlot;
+                            root.buttonHovered = true;
+                        }
+                        exitedAction: () => {
+                            if (root.lastHoveredButton === activeSlot)
+                                hoverGraceTimer.restart();
+                        }
+
                         onClicked: {
                             if (activeSlot.modelData.toplevels.length === 0) return
                             const next = (activeSlot._lastFocused + 1) % activeSlot.modelData.toplevels.length
@@ -597,7 +621,14 @@ Item {
                             TaskbarApps.togglePin(activeSlot.modelData.appId)
                         }
                         backClickAction: () => {
-                            Hyprland.dispatch("hl.dsp.workspace.toggle_special('special')")
+                            root.buttonHovered = false;
+                            root.lastHoveredButton = null;
+                            Hyprland.dispatch("hl.dsp.workspace.toggle_special('special')");
+                        }
+
+                        StyledToolTip {
+                            text: activeSlot.appTitle
+                            extraVisibleCondition: (Config.options?.dockToPanel?.enableTooltip ?? true) && !(Config.options?.dockToPanel?.enablePreview ?? false)
                         }
 
                         contentItem: Item {
@@ -687,25 +718,78 @@ Item {
         }
     }
 
-    // ── Tooltip and Window Preview ───────────────────────────────────────
-    Loader {
-        id: tooltipLoader
-        active: Config.options?.dockToPanel?.enableTooltip ?? true
-        sourceComponent: DockTooltip {
-            parentItem: root.lastHoveredButton
-            text: root.lastHoveredButton?.appTitle ?? ""
-            showTooltip: root.buttonHovered && !root.scratchpadOpen && text !== ""
-            dockPosition: root.dockEffectivePosition === "top" ? "bottom" : (root.dockEffectivePosition === "bottom" ? "top" : (root.dockEffectivePosition === "left" ? "right" : "left"))
-        }
-    }
+    // ── Window Preview Popup (Bar Native) ──────────────────────────────
+    StyledPopup {
+        id: previewPopup
+        hoverTarget: root.lastHoveredButton
+        stickyHover: true
+        active: (Config.options?.dockToPanel?.enablePreview ?? true) && !(Config.options?.dockToPanel?.enableTooltip ?? false) && !root.scratchpadOpen && (root.buttonHovered || previewPopup._popupHovered) && (root.lastHoveredButton?.appToplevel?.toplevels?.length ?? 0) > 0
 
-    Loader {
-        id: previewPopupLoader
-        active: Config.options?.dockToPanel?.enablePreview ?? true
-        sourceComponent: DockPreviewPopup {
-            dockRoot: root
-            dockWindow: root.QsWindow.window
-            appTopLevel: root.lastHoveredButton?.appToplevel
+        contentItem: RowLayout {
+            spacing: 8
+            Repeater {
+                model: ScriptModel {
+                    values: (root.lastHoveredButton?.appToplevel?.toplevels ?? []).slice(0, 4)
+                }
+                delegate: RippleButton {
+                    id: winBtn
+                    required property var modelData
+                    implicitWidth: screencopyView.implicitWidth + 12
+                    implicitHeight: screencopyView.implicitHeight + 36
+                    buttonRadius: Appearance.rounding.small
+
+                    onClicked: {
+                        modelData?.activate();
+                        root.buttonHovered = false;
+                    }
+                    middleClickAction: () => modelData?.close()
+
+                    contentItem: ColumnLayout {
+                        anchors.centerIn: parent
+                        spacing: 4
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 4
+                            StyledText {
+                                Layout.fillWidth: true
+                                text: winBtn.modelData?.title ?? ""
+                                font.pixelSize: Appearance.font.pixelSize.small
+                                elide: Text.ElideRight
+                                color: Appearance.colors.colOnSurface
+                            }
+                            RippleButton {
+                                implicitWidth: 18
+                                implicitHeight: 18
+                                buttonRadius: Appearance.rounding.full
+                                contentItem: MaterialSymbol {
+                                    anchors.centerIn: parent
+                                    text: "close"
+                                    iconSize: 12
+                                    color: Appearance.colors.colOnSurface
+                                }
+                                onClicked: winBtn.modelData?.close()
+                            }
+                        }
+
+                        ScreencopyView {
+                            id: screencopyView
+                            captureSource: winBtn.modelData
+                            live: true
+                            paintCursor: true
+                            constraintSize: Qt.size(240, 150)
+                            layer.enabled: true
+                            layer.effect: OpacityMask {
+                                maskSource: Rectangle {
+                                    width: screencopyView.width
+                                    height: screencopyView.height
+                                    radius: Appearance.rounding.small
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/dockToPanel/DockToPanel.qml
@@ -27,9 +27,10 @@ Item {
     readonly property bool alignToWorkspace: Config.options?.dockToPanel?.alignToWorkspace ?? false
     readonly property bool enableWorkspaceScroll: Config.options?.dockToPanel?.enableWorkspaceScroll ?? true
 
-    // Scratchpad detection
-    readonly property var scratchpadWin: HyprlandData.windowList.find(w => w.workspace && w.workspace.name && w.workspace.name.startsWith("special"))
-    readonly property bool scratchpadOpen: scratchpadWin !== undefined
+    // Scratchpad detection (matching Workspaces.qml pattern)
+    readonly property var currentHyprlandMonitorData: HyprlandData.monitors.find(mon => mon.name === root.monitor?.name)
+    readonly property bool scratchpadOpen: !!(currentHyprlandMonitorData && currentHyprlandMonitorData.specialWorkspace && currentHyprlandMonitorData.specialWorkspace.name !== "")
+    readonly property var scratchpadWin: scratchpadOpen ? HyprlandData.windowList.find(w => w.workspace && w.workspace.id === currentHyprlandMonitorData.specialWorkspace.id) : null
     readonly property string scratchpadAppId: scratchpadWin ? TaskbarApps.normalizeAppId(scratchpadWin.class) : ""
 
     property var activeUnpinned: TaskbarApps.apps.filter(a => {
@@ -234,9 +235,9 @@ Item {
             onWheel: event => {
                 let delta = event.angleDelta.y !== 0 ? event.angleDelta.y : event.angleDelta.x;
                 if (delta > 0)
-                    Hyprland.dispatch("workspace e-1");
+                    Hyprland.dispatch("workspace", "e-1");
                 else if (delta < 0)
-                    Hyprland.dispatch("workspace e+1");
+                    Hyprland.dispatch("workspace", "e+1");
             }
         }
 
@@ -290,8 +291,8 @@ Item {
                     }
 
                     z: isDragged ? 100 : 0
-                    opacity: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.25) : (isDragged ? 0.85 : 1.0)
-                    scale: isDragged ? 1.05 : 1
+                    opacity: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.35) : (isDragged ? 0.85 : 1.0)
+                    scale: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.85) : (isDragged ? 1.05 : 1.0)
 
                     Behavior on opacity {
                         enabled: !root._suppressTranslateAnim
@@ -381,7 +382,7 @@ Item {
                         }
                         middleClickAction: () => { slotItem.deskEntry?.execute() }
                         altAction:         () => { TaskbarApps.togglePin(slotItem.appId) }
-                        backClickAction:   () => { Hyprland.dispatch("togglespecialworkspace scratchpad") }
+                        backClickAction:   () => { Hyprland.dispatch("togglespecialworkspace", "scratchpad") }
 
                         contentItem: Item {
                             anchors.centerIn: parent
@@ -505,7 +506,23 @@ Item {
 
                     width:  root.btnSize
                     height: root.btnSize
-                    opacity: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.25) : 1.0
+                    opacity: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.35) : 1.0
+                    scale: root.scratchpadOpen ? (isScratchpadApp ? 1.0 : 0.85) : 1.0
+
+                    Behavior on opacity {
+                        NumberAnimation {
+                            duration: Appearance.animation.elementMoveFast.duration
+                            easing.type: Appearance.animation.elementMoveFast.type
+                            easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                        }
+                    }
+                    Behavior on scale {
+                        NumberAnimation {
+                            duration: Appearance.animation.elementMoveFast.duration
+                            easing.type: Appearance.animation.elementMoveFast.type
+                            easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                        }
+                    }
 
                     RippleButton {
                         anchors.fill: parent
@@ -525,7 +542,7 @@ Item {
                             TaskbarApps.togglePin(activeSlot.modelData.appId)
                         }
                         backClickAction: () => {
-                            Hyprland.dispatch("togglespecialworkspace scratchpad")
+                            Hyprland.dispatch("togglespecialworkspace", "scratchpad")
                         }
 
                         contentItem: Item {

--- a/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
@@ -1,0 +1,72 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+
+ContentPage {
+    id: root
+    forceWidth: false
+
+    signal goBack()
+
+    RowLayout {
+        spacing: 12
+
+        RippleButton {
+            implicitWidth: implicitHeight
+            implicitHeight: 40
+            topLeftRadius: Appearance.rounding.full
+            topRightRadius: Appearance.rounding.full
+            bottomLeftRadius: Appearance.rounding.full
+            bottomRightRadius: Appearance.rounding.full
+            colBackground: Appearance.colors.colSecondaryContainer
+            colBackgroundHover: Appearance.colors.colSecondaryContainerHover
+            colRipple: Appearance.colors.colSecondaryContainerActive
+
+            MaterialSymbol {
+                anchors.centerIn: parent
+                text: "arrow_back"
+                iconSize: Appearance.font.pixelSize.large
+                color: Appearance.colors.colOnSecondaryContainer
+            }
+
+            onClicked: root.goBack()
+        }
+
+        StyledText {
+            text: Translation.tr("Dock to Panel")
+            font.pixelSize: Appearance.font.pixelSize.large
+            font.family: Appearance.font.family.title
+            color: Appearance.colors.colOnLayer0
+        }
+    }
+
+    ContentSection {
+        icon: "apps"
+        title: Translation.tr("Dock to Panel")
+
+        ConfigSpinBox {
+            icon: "height"
+            text: Translation.tr("Icon size")
+            value: Config.options.dockToPanel.iconSize
+            from: 17
+            to: 40
+            stepSize: 1
+            onValueChanged: {
+                Config.options.dockToPanel.iconSize = value;
+            }
+        }
+        ConfigSpinBox {
+            icon: "format_letter_spacing"
+            text: Translation.tr("Button spacing")
+            value: Config.options.dockToPanel.buttonSpacing
+            from: 0
+            to: 10
+            stepSize: 1
+            onValueChanged: {
+                Config.options.dockToPanel.buttonSpacing = value;
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
@@ -84,5 +84,21 @@ ContentPage {
                 Config.options.dockToPanel.alignToWorkspace = checked;
             }
         }
+        ConfigSwitch {
+            buttonIcon: "subtitles"
+            text: Translation.tr("Enable app name tooltips")
+            checked: Config.options.dockToPanel.enableTooltip
+            onCheckedChanged: {
+                Config.options.dockToPanel.enableTooltip = checked;
+            }
+        }
+        ConfigSwitch {
+            buttonIcon: "preview"
+            text: Translation.tr("Enable window preview popups")
+            checked: Config.options.dockToPanel.enablePreview
+            onCheckedChanged: {
+                Config.options.dockToPanel.enablePreview = checked;
+            }
+        }
     }
 }

--- a/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
@@ -106,5 +106,25 @@ ContentPage {
                 }
             }
         }
+        ConfigSwitch {
+            buttonIcon: "zoom_in"
+            text: Translation.tr("Enable macOS icon magnification")
+            checked: Config.options.dockToPanel.enableMacOsMagnification
+            onCheckedChanged: {
+                Config.options.dockToPanel.enableMacOsMagnification = checked;
+            }
+        }
+        ConfigSpinBox {
+            visible: Config.options.dockToPanel.enableMacOsMagnification ?? false
+            icon: "zoom_in_map"
+            text: Translation.tr("Magnification intensity (%)")
+            value: Math.round((Config.options.dockToPanel.macOsMagnificationScale ?? 1.6) * 100)
+            from: 120
+            to: 220
+            stepSize: 10
+            onValueChanged: {
+                Config.options.dockToPanel.macOsMagnificationScale = value / 100.0;
+            }
+        }
     }
 }

--- a/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
@@ -90,6 +90,9 @@ ContentPage {
             checked: Config.options.dockToPanel.enableTooltip
             onCheckedChanged: {
                 Config.options.dockToPanel.enableTooltip = checked;
+                if (checked) {
+                    Config.options.dockToPanel.enablePreview = false;
+                }
             }
         }
         ConfigSwitch {
@@ -98,6 +101,9 @@ ContentPage {
             checked: Config.options.dockToPanel.enablePreview
             onCheckedChanged: {
                 Config.options.dockToPanel.enablePreview = checked;
+                if (checked) {
+                    Config.options.dockToPanel.enableTooltip = false;
+                }
             }
         }
     }

--- a/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
@@ -69,7 +69,7 @@ ContentPage {
             }
         }
         ConfigSwitch {
-            icon: "swap_calls"
+            buttonIcon: "swap_calls"
             text: Translation.tr("Enable workspace scrolling")
             checked: Config.options.dockToPanel.enableWorkspaceScroll
             onCheckedChanged: {
@@ -77,7 +77,7 @@ ContentPage {
             }
         }
         ConfigSwitch {
-            icon: "grid_view"
+            buttonIcon: "grid_view"
             text: Translation.tr("Align apps to current workspace")
             checked: Config.options.dockToPanel.alignToWorkspace
             onCheckedChanged: {

--- a/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/widgets/DockToPanelConfig.qml
@@ -68,5 +68,21 @@ ContentPage {
                 Config.options.dockToPanel.buttonSpacing = value;
             }
         }
+        ConfigSwitch {
+            icon: "swap_calls"
+            text: Translation.tr("Enable workspace scrolling")
+            checked: Config.options.dockToPanel.enableWorkspaceScroll
+            onCheckedChanged: {
+                Config.options.dockToPanel.enableWorkspaceScroll = checked;
+            }
+        }
+        ConfigSwitch {
+            icon: "grid_view"
+            text: Translation.tr("Align apps to current workspace")
+            checked: Config.options.dockToPanel.alignToWorkspace
+            onCheckedChanged: {
+                Config.options.dockToPanel.alignToWorkspace = checked;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Describe your changes

Adds dock to panel bar widget from pC-trade fork
Add animation for grabbing apps just like in a regular dock

<img width="218" height="54" alt="image" src="https://github.com/user-attachments/assets/ec2d2df5-4ffe-4116-a7b3-bc8ff626b9d8" />

## Is it ready? Questions/feedback needed?
Everything is tested and working as expected