### PR TITLE
FEAT(cheatsheet): bind doc

### DIFF
--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -112,13 +112,13 @@ hl.bind("SUPER + SHIFT + ALT + mouse:273", hl.dsp.exec_cmd(hyprScripts .. "/ai/p
 hl.bind("SUPER + mouse:272", hl.dsp.window.drag(), { mouse = true, description = "Window: Move" })
 hl.bind("SUPER + mouse:274", hl.dsp.window.drag(), { mouse = true })
 hl.bind("SUPER + mouse:273", hl.dsp.window.resize(), { mouse = true, description = "Window: Resize" })
---#/# bind = SUPER + ←/↑/→/↓,, -- Focus in direction
+--#/# bind = SUPER, ←/↑/→/↓,, # Focus in direction
 for i = 1, 6 do
     local arrowkey = { "Left", "Right", "Up", "Down", "BracketLeft", "BracketRight" }
     local focusdir = { "l", "r", "u", "d", "l", "r" }
     hl.bind("SUPER + " .. arrowkey[i], hl.dsp.focus({ direction = focusdir[i] }))
 end
---#/# bind = SUPER + SHIFT, ←/↑/→/↓,, -- Move in direction
+--#/# bind = SUPER + SHIFT, ←/↑/→/↓,, # Move in direction
 for i = 1, 4 do
     local arrowkey = { "Left", "Right", "Up", "Down" }
     local focusdir = { "l", "r", "u", "d" }
@@ -133,7 +133,7 @@ hl.bind("SUPER + Q", hl.dsp.window.close(), { description = "Window: Close" })
 hl.bind("SUPER + SHIFT + ALT + Q", hl.dsp.exec_cmd("hyprctl kill"), { description = "Window: Forcefully zap a window" })
 
 --# Window split ratio
---#/# binde = SUPER, ;/',, -- Adjust split ratio
+--#/# binde = SUPER, ;/',, # Adjust split ratio
 hl.bind("SUPER + Semicolon", hl.dsp.layout("splitratio -0.1"), { repeating = true })
 hl.bind("SUPER + Apostrophe", hl.dsp.layout("splitratio +0.1"), { repeating = true })
 --# Positioning mode
@@ -146,7 +146,7 @@ hl.bind("SUPER + ALT + F", hl.dsp.window.fullscreen_state({ internal = 0, client
     { description = "Window: Fullscreen spoof" })
 hl.bind("SUPER + P", hl.dsp.window.pin(), { description = "Window: Pin" })
 
---#/# bind = SUPER+ALT, Hash,, -- Send to workspace -- (1, 2, 3,...)
+--#/# bind = SUPER+ALT, Hash,, # Silently send to workspace (1, 2, 3,...)
 --# We use raw keycodes because some keyboard layouts register number keys as different chars. The codes can be verified with `wev`
 for i = 1, 10 do
     local numberkey = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 }
@@ -176,7 +176,7 @@ for i = 1, 10 do
     end)
 end
 
---# #/# bind = SUPER+SHIFT, Scroll ↑/↓,, -- Send to workspace left/right
+--# #/# bind = SUPER+SHIFT, Scroll ↑/↓,, # Send to workspace left/right
 for i = 1, 4 do
     local key = { "SUPER + SHIFT + mouse_", "SUPER + ALT + mouse_" }
     local keycombos = { key[1] .. "down", key[1] .. "up", key[2] .. "down", key[2] .. "up" }
@@ -184,7 +184,7 @@ for i = 1, 4 do
     hl.bind(keycombos[i], hl.dsp.window.move({ workspace = prefix[i] .. "1" }))
 end
 
---#/# bind = SUPER+SHIFT, Page_↑/↓,, -- Send to workspace left/right
+--#/# bind = SUPER+SHIFT, Page_↑/↓,, # Send to workspace left/right
 for i = 1, 6 do
     local key = { "SUPER + ALT + Page_", "SUPER + SHIFT + Page_", "CTRL + SUPER + SHIFT + " }
     local keycombos = { key[1] .. "down", key[1] .. "up", key[2] .. "down", key[2] .. "up", key[3] .. "Right", key[3] ..
@@ -193,7 +193,6 @@ for i = 1, 6 do
     hl.bind(keycombos[i], hl.dsp.window.move({ workspace = prefix[i] .. "1" })) -- # [hidden]
 end
 
---#/# bind = CTRL+SUPER, C,, -- Compact workspaces into 1..N (remove empty gaps)
 hl.bind("CTRL + SUPER + C", hl.dsp.exec_cmd(qsScripts .. "/hyprland/workspace_compactor"),
     { description = "Workspaces: Compact into 1..N (remove empty gaps)" })
 
@@ -237,7 +236,7 @@ hl.bind("CTRL + SUPER + S", hl.dsp.workspace.toggle_special("special"))
 
 --##! Workspace
 --# Switching
---#/# bind = SUPER, Hash,, -- Focus workspace -- (1, 2, 3,...)
+--#/# bind = SUPER, Hash,, # Focus workspace (1, 2, 3,...)
 --# We use raw keycodes because some keyboard layouts register number keys as different chars. The codes can be verified with `wev`
 for i = 1, 10 do
     local numberkey = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 }
@@ -253,22 +252,22 @@ for i = 1, 10 do
     end)
 end
 
---#/# bind = CTRL+SUPER, ←/→,, -- Focus left/right
---#/# bind = CTRL+SUPER+ALT, ←/→,, -- # [hidden] Focus busy left/right
+--#/# bind = CTRL+SUPER, ←/→,, # Focus left/right
+--#/# bind = CTRL+SUPER+ALT, ←/→,, # [hidden] Focus busy left/right
 for i = 1, 4 do
     local key = { "CTRL + SUPER + ", "CTRL + SUPER + ALT + " }
     local keycombos = { key[1] .. "Right", key[1] .. "Left", key[2] .. "Right", key[2] .. "Left" }
     local prefix = { "+", "-", "m+", "m-" }
     hl.bind(keycombos[i], hl.dsp.focus({ workspace = prefix[i] .. "1" }))
 end
---#/# bind = SUPER, Page_↑/↓,, -- Focus left/right
+--#/# bind = SUPER, Page_↑/↓,, # Focus left/right
 for i = 1, 4 do
     local key = { "SUPER + Page_Down", "SUPER + Page_Up" }
     local keycombos = { key[1], key[2], "CTRL + " .. key[1], "CTRL + " .. key[2] }
     local prefix = { "+", "-", "r+", "r-" }
     hl.bind(keycombos[i], hl.dsp.focus({ workspace = prefix[i] .. "1" }))
 end
---#/# bind = SUPER, Scroll ↑/↓,, -- Focus left/right
+--#/# bind = SUPER, Scroll ↑/↓,, # Focus left/right
 for i = 1, 4 do
     local key = { "SUPER + mouse_up", "SUPER + mouse_down" }
     local keycombos = { key[1], key[2], "CTRL + " .. key[1], "CTRL + " .. key[2] }

--- a/dots/.config/quickshell/ii/scripts/hyprland/get_keybinds.py
+++ b/dots/.config/quickshell/ii/scripts/hyprland/get_keybinds.py
@@ -112,6 +112,7 @@ LUA_BIND_RE = re.compile(r'hl\.bind\s*\(([^)]*)\)\s*', re.DOTALL)
 LUA_FIRST_ARG_RE = re.compile(r'"([^"]+)"')
 LUA_DESC_RE = re.compile(r'description\s*=\s*"([^"]*)"')
 LUA_SECTION_RE = re.compile(r'^--##!\s+(.+)$')
+LUA_COMMENT_BIND_PATTERN = re.compile(r'^--?#/#\s+(bind|unbind)\s*=')
 
 
 def parse_lua_binds(path):
@@ -169,7 +170,18 @@ def parse_lua_binds(path):
             process_lua_bind(bind_src, current, is_unbind=True)
             continue
 
-        # Skip `--#/#` documentation lines (old conf-format bind documentation, not active)
+        # Cheatsheet-only documentation binds (not registered with Hyprland)
+        # e.g. `--#/# bind = SUPER+SHIFT, ↑/↓/←/→,, # Move workspace to monitor`
+        if re.match(LUA_COMMENT_BIND_PATTERN, stripped):
+            # Strip leading `--` so conf-style parsing sees `#/# bind = ...`
+            lines[i] = stripped[2:].lstrip() if stripped.startswith("--") else stripped
+            keybind = get_keybind_at_line(i, lines)
+            if isinstance(keybind, KeyBinding):
+                current["keybinds"].append(keybind)
+            elif isinstance(keybind, Unbinding):
+                current["unbinds"].append(keybind)
+            i += 1
+            continue
 
         i += 1
 


### PR DESCRIPTION
## Describe your changes
brings back the bind doc feature that was omitted during luaification
allows adding "ghost" keybinds to the cheatsheet without registering real hyprland keybinds
also fixes existing ones in the general.lua
unbinding also works like this `--#/# unbind = SUPER, ←/↑/→/↓`
<img width="554" height="227" alt="image" src="https://github.com/user-attachments/assets/780643c1-2f97-40a2-9a3e-8d8d7c5f6b3e" />
<img width="616" height="173" alt="image" src="https://github.com/user-attachments/assets/b3f6e70e-6eee-413b-a38f-eb151bc2f5d5" />
<img width="729" height="180" alt="image" src="https://github.com/user-attachments/assets/cb8a3d07-9807-4f73-aaa0-c41df1ded46c" />


<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yes. I think format can be improved by removing redunant (additional) `,`. but didn't bother do that in this one 

