### PR TITLE
FIX(DevicesPhoneConfig): "No Bluetooth devices" pane

### DIFF
--- a/dots/.config/quickshell/ii/modules/settings/configs/DevicesPhoneConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/configs/DevicesPhoneConfig.qml
@@ -227,7 +227,7 @@ ContentPage {
 
         Item {
             Layout.fillWidth: true
-            Layout.fillHeight: true
+            implicitHeight: 250
             visible: btImagesSection.getAvailableDevices().length === 0 && btImagesSection.getDeviceImages().length === 0
 
             PagePlaceholder {


### PR DESCRIPTION
## Describe your changes
adjust implicit height for DevicesPhoneConfig thingie for "No Bluetooth devices" pane
before:
<img width="1780" height="383" alt="image" src="https://github.com/user-attachments/assets/5f3c0bbe-182a-424a-95f6-60e345f53b73" />
after:
<img width="878" height="401" alt="image" src="https://github.com/user-attachments/assets/aadfd663-8da3-4e39-8853-848e589ea1b9" />


<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?


