### PR TITLE
refactor(bar widgets): edit material component to draw circle when pr…

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/MaterialBarWidget.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/MaterialBarWidget.qml
@@ -11,16 +11,11 @@ Item {
     property Component secondaryComponent
 
     property bool primaryIsCircle: false
+    property bool secondaryIsCircleWhenAlone: false
     property bool secondaryOpposite: false
     property bool swapPrimaryWithSecondary: false
     property bool showPrimary: true
     property bool showSecondary: true
-
-    readonly property bool secondaryIsLeft:
-        showPrimary && showSecondary && secondaryOpposite
-
-    readonly property bool onlySecondary:
-        !showPrimary && showSecondary
 
     property real primaryPadding: 8
     property real primaryExtraMargin: 0
@@ -29,115 +24,84 @@ Item {
     property real secondaryOnlyMargin: 8
     property real componentsPadding: 8
 
+    readonly property bool secondaryIsLeft: showPrimary && showSecondary && secondaryOpposite
+    readonly property bool onlySecondary: !showPrimary && showSecondary
     readonly property real baseMargin: 4
+    readonly property Component primarySource: swapPrimaryWithSecondary ? secondaryComponent : primaryComponent
+    readonly property Component secondarySource: swapPrimaryWithSecondary ? primaryComponent : secondaryComponent
+    readonly property real leftPadding: baseMargin + ( showPrimary && showSecondary
+                                                    ? (secondaryIsLeft ? secondaryExtraMargin : primaryExtraMargin)
+                                                    : (onlySecondary ? secondaryOnlyMargin : primaryExtraMargin)
+                                                    )
+    readonly property real rightPadding: baseMargin + ( showPrimary && showSecondary
+                                                    ? (secondaryIsLeft ? primaryExtraMargin : secondaryExtraMargin)
+                                                    : (onlySecondary ? secondaryOnlyMargin : primaryExtraMargin)
+                                                    )
+    readonly property real primaryWidth: showPrimary && primaryMeasure.item ? primaryMeasure.item.implicitWidth : 0
+    readonly property real secondaryWidth: showSecondary && secondaryMeasure.item ? secondaryMeasure.item.implicitWidth : 0
 
-    readonly property Component primarySource:
-        swapPrimaryWithSecondary ? secondaryComponent : primaryComponent
-
-    readonly property Component secondarySource:
-        swapPrimaryWithSecondary ? primaryComponent : secondaryComponent
-
-    readonly property real leftPadding:
-        baseMargin + (
-            showPrimary && showSecondary
-                ? (secondaryIsLeft ? secondaryExtraMargin : primaryExtraMargin)
-                : (onlySecondary ? secondaryOnlyMargin : primaryExtraMargin)
-        )
-
-    readonly property real rightPadding:
-        baseMargin + (
-            showPrimary && showSecondary
-                ? (secondaryIsLeft ? primaryExtraMargin : secondaryExtraMargin)
-                : (onlySecondary ? secondaryOnlyMargin : primaryExtraMargin)
-        )
-
-    readonly property real primaryWidth:
-        showPrimary && primaryMeasure.item
-            ? primaryMeasure.item.implicitWidth
-            : 0
-
-    readonly property real secondaryWidth:
-        showSecondary && secondaryMeasure.item
-            ? secondaryMeasure.item.implicitWidth
-            : 0
-
-    implicitWidth:
-        leftPadding
-        + rightPadding
-        + primaryWidth
-        + secondaryWidth
-        + ((showPrimary && showSecondary)
-            ? componentsPadding
-            : 0)
-
-    implicitHeight:
-        Appearance.sizes.baseBarHeight - 8
+    implicitWidth: {
+        if (onlySecondary && secondaryIsCircleWhenAlone) {
+            return implicitHeight;
+        }
+        return leftPadding + rightPadding + primaryWidth + secondaryWidth + ((showPrimary && showSecondary) ? componentsPadding : 0)
+    }
+    implicitHeight: Appearance.sizes.baseBarHeight - 8
 
     Loader {
         id: primaryMeasure
-
         visible: false
         active: root.showPrimary
-
         sourceComponent: primaryWrapper
     }
 
     Loader {
         id: secondaryMeasure
-
         visible: false
         active: root.showSecondary
-
         sourceComponent: secondarySource
     }
 
     Rectangle {
         id: pill
-
         anchors.centerIn: parent
-
-        width: root.implicitWidth
+        width: root.secondaryIsCircleWhenAlone && !showPrimary ? root.implicitHeight : root.implicitWidth
         height: root.implicitHeight
-
         color: Appearance.colors.colPrimaryContainer
         radius: Appearance.rounding.full
 
-        Row {
-            anchors {
-                fill: parent
-                leftMargin: root.leftPadding
-                rightMargin: root.rightPadding
-            }
-
-            spacing:
-                root.showPrimary && root.showSecondary
-                    ? root.componentsPadding
-                    : 0
+        Item {
+            anchors.fill: parent
 
             Loader {
-                anchors.verticalCenter: parent.verticalCenter
-
-                active:
-                    root.showPrimary || root.onlySecondary
-
-                sourceComponent:
-                    root.onlySecondary
-                        ? root.secondarySource
-                        : root.secondaryIsLeft
-                            ? root.secondarySource
-                            : primaryWrapper
+                id: contentLoader
+                anchors.centerIn: parent
+                active: root.onlySecondary && root.secondaryIsCircleWhenAlone
+                sourceComponent: root.secondarySource
             }
 
-            Loader {
-                anchors.verticalCenter: parent.verticalCenter
+            Row {
+                anchors {
+                    fill: parent
+                    leftMargin: root.leftPadding
+                    rightMargin: root.rightPadding
+                }
+                spacing: root.showPrimary && root.showSecondary ? root.componentsPadding : 0
 
-                active:
-                    root.showPrimary && root.showSecondary
+                Loader {
+                    anchors.verticalCenter: parent.verticalCenter
+                    active: root.showPrimary || (root.onlySecondary && !root.secondaryIsCircleWhenAlone)
+                    sourceComponent: root.onlySecondary ? root.secondarySource
+                                                        : root.secondaryIsLeft
+                                                            ? root.secondarySource
+                                                            : primaryWrapper
+                }
 
-                sourceComponent:
-                    root.secondaryIsLeft
-                        ? primaryWrapper
-                        : root.secondarySource
+                Loader {
+                    anchors.verticalCenter: parent.verticalCenter
+                    active: root.showPrimary && root.showSecondary
+                    sourceComponent: root.secondaryIsLeft ? primaryWrapper : root.secondarySource
+                }
             }
         }
     }
@@ -148,29 +112,17 @@ Item {
         Rectangle {
             color: Appearance.colors.colPrimary
             radius: Appearance.rounding.full
-
-            implicitHeight:
-                pill.height - root.primaryPadding
-
-            implicitWidth:
-                root.primaryIsCircle && !root.swapPrimaryWithSecondary
-                    ? implicitHeight
-                    : (content.item
-                        ? content.item.implicitWidth
-                        : 0)
-                      + root.primaryPadding * 2
-                      + root.primaryWidthOffset
-
+            implicitHeight: pill.height - root.primaryPadding
+            implicitWidth: root.primaryIsCircle ? implicitHeight
+                                                : (content.item ? content.item.implicitWidth : 0)
+                                                + root.primaryPadding * 2 + root.primaryWidthOffset
             width: implicitWidth
             height: implicitHeight
 
             Loader {
                 id: content
-
                 anchors.centerIn: parent
-
-                sourceComponent:
-                    root.primarySource
+                sourceComponent: root.primarySource
             }
         }
     }

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/battery/BatteryIndicator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/battery/BatteryIndicator.qml
@@ -313,7 +313,7 @@ MouseArea {
             MaterialBarWidget {
                 primaryComponent: batteryIndicatorComponent
                 secondaryComponent: batteryPercentageComponent
-                secondaryExtraMargin: 4
+                secondaryExtraMargin: 6
                 componentsPadding: 6
 
                 showSecondary: Config.options.bar.battery.showSecondary
@@ -352,7 +352,6 @@ MouseArea {
                                 id: batteryProgress
                                 width: 26
                                 height: 14
-
                                 radius: 4.5
 
                                 value: root.percentage

--- a/dots/.config/quickshell/ii/modules/ii/bar/widgets/keyboard/KeyboardLayoutWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/widgets/keyboard/KeyboardLayoutWidget.qml
@@ -86,6 +86,7 @@ MouseArea {
                 primaryComponent: iconComponent
                 secondaryComponent: keyboardLayoutComponent
                 primaryIsCircle: true
+                secondaryIsCircleWhenAlone: true
                 secondaryExtraMargin: 4
                 componentsPadding: 6
 
@@ -133,7 +134,7 @@ MouseArea {
                         TextMetrics {
                             id: metrics
                             font: keyboardText.font
-                            text: root.uppercaseLayout ? "UU UU" : "uu uu"
+                            text: root.uppercaseLayout ? "WW" : "ww"
                         }
                     }
                 }

--- a/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalKeyboardLayoutWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalKeyboardLayoutWidget.qml
@@ -89,6 +89,7 @@ MouseArea {
                 primaryComponent: keyboardIcon
                 secondaryComponent: keyboardLayout
                 primaryIsCircle: true
+                secondaryIsCircleWhenAlone: true
                 
                 showSecondary: Config.options.bar.keyboardLayout.showSecondary
                 secondaryOpposite: Config.options.bar.keyboardLayout.secondaryOpposite

--- a/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalMaterialBarWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/verticalBar/VerticalMaterialBarWidget.qml
@@ -11,68 +11,44 @@ Item {
     property Component secondaryComponent
 
     property bool primaryIsCircle: false
+    property bool secondaryIsCircleWhenAlone: false
     property bool secondaryOpposite: false
     property bool swapPrimaryWithSecondary: false
     property bool showPrimary: true
     property bool showSecondary: true
 
-    readonly property bool secondaryIsAbove:
-        showPrimary && showSecondary && secondaryOpposite
-
-    readonly property bool onlySecondary:
-        !showPrimary && showSecondary
-
     property real primaryPadding: 8
     property real primaryExtraMargin: 0
     property real primaryHeightOffset: -4
-    property real secondaryExtraMargin: 4
+    property real secondaryExtraMargin: 6
 
+    readonly property bool secondaryIsAbove: showPrimary && showSecondary && secondaryOpposite
+    readonly property bool onlySecondary: !showPrimary && showSecondary
     readonly property real baseMargin: 4
     readonly property real componentsPadding: 4
+    readonly property Component primarySource: swapPrimaryWithSecondary ? secondaryComponent : primaryComponent
+    readonly property Component secondarySource: swapPrimaryWithSecondary ? primaryComponent : secondaryComponent
+    readonly property real topPadding: baseMargin + (showPrimary && showSecondary
+                                                    ? (secondaryIsAbove ? secondaryExtraMargin : primaryExtraMargin)
+                                                    : primaryExtraMargin
+                                                    )
+    readonly property real bottomPadding: baseMargin + (showPrimary && showSecondary
+                                                    ? (secondaryIsAbove ? primaryExtraMargin : secondaryExtraMargin)
+                                                    : primaryExtraMargin
+                                                    )
+    readonly property real primaryHeight: showPrimary && primaryMeasure.item ? primaryMeasure.item.implicitHeight : 0
+    readonly property real secondaryHeight: showSecondary && secondaryMeasure.item ? secondaryMeasure.item.implicitHeight : 0
 
-    readonly property Component primarySource:
-        swapPrimaryWithSecondary ? secondaryComponent : primaryComponent
-
-    readonly property Component secondarySource:
-        swapPrimaryWithSecondary ? primaryComponent : secondaryComponent
-
-    readonly property real topPadding:
-        baseMargin + (
-            showPrimary && showSecondary
-                ? (secondaryIsAbove ? secondaryExtraMargin : primaryExtraMargin)
-                : primaryExtraMargin
-        )
-
-    readonly property real bottomPadding:
-        baseMargin + (
-            showPrimary && showSecondary
-                ? (secondaryIsAbove ? primaryExtraMargin : secondaryExtraMargin)
-                : primaryExtraMargin
-        )
-
-    readonly property real primaryHeight:
-        showPrimary && primaryMeasure.item
-            ? primaryMeasure.item.implicitHeight
-            : 0
-
-    readonly property real secondaryHeight:
-        showSecondary && secondaryMeasure.item
-            ? secondaryMeasure.item.implicitHeight
-            : 0
-
-    implicitWidth:
-        Appearance.sizes.baseVerticalBarWidth - 8
-
-    implicitHeight:
-        topPadding
-        + bottomPadding
-        + primaryHeight
-        + secondaryHeight
-        + ((showPrimary && showSecondary) ? componentsPadding : 0)
+    implicitWidth: Appearance.sizes.baseVerticalBarWidth - 8
+    implicitHeight: {
+        if (onlySecondary && secondaryIsCircleWhenAlone) {
+            return implicitWidth;
+        }
+        return topPadding + bottomPadding + primaryHeight + secondaryHeight + ((showPrimary && showSecondary) ? componentsPadding : 0);
+    }
 
     Loader {
         id: primaryMeasure
-
         visible: false
         active: root.showPrimary
         sourceComponent: primaryWrapper
@@ -80,7 +56,6 @@ Item {
 
     Loader {
         id: secondaryMeasure
-
         visible: false
         active: root.showSecondary
         sourceComponent: secondarySource
@@ -88,82 +63,61 @@ Item {
 
     Rectangle {
         id: pill
-
         anchors.centerIn: parent
-
         width: root.implicitWidth
-        height: root.implicitHeight
-
+        height: root.secondaryIsCircleWhenAlone && !showPrimary ? root.implicitWidth : root.implicitHeight
         color: Appearance.colors.colPrimaryContainer
         radius: Appearance.rounding.full
 
-        Column {
-            anchors {
-                fill: parent
-                topMargin: root.topPadding
-                bottomMargin: root.bottomPadding
-            }
-
-            spacing:
-                root.showPrimary && root.showSecondary
-                    ? root.componentsPadding
-                    : 0
+        Item {
+            anchors.fill: parent
 
             Loader {
-                anchors.horizontalCenter: parent.horizontalCenter
-
-                active:
-                    root.showPrimary || root.onlySecondary
-
-                sourceComponent:
-                    root.onlySecondary
-                        ? root.secondarySource
-                        : root.secondaryIsAbove
-                            ? root.secondarySource
-                            : primaryWrapper
+                id: contentLoader
+                anchors.centerIn: parent
+                active: root.onlySecondary
+                sourceComponent: root.secondarySource
             }
 
-            Loader {
-                anchors.horizontalCenter: parent.horizontalCenter
+            Column {
+                anchors {
+                    fill: parent
+                    topMargin: root.topPadding
+                    bottomMargin: root.bottomPadding
+                }
+                spacing: root.showPrimary && root.showSecondary ? root.componentsPadding : 0
+                visible: !root.onlySecondary
 
-                active:
-                    root.showPrimary && root.showSecondary
+                Loader {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    active: root.showPrimary || root.onlySecondary
+                    sourceComponent: root.onlySecondary ? root.secondarySource : (root.secondaryIsAbove ? root.secondarySource : primaryWrapper)
+                }
 
-                sourceComponent:
-                    root.secondaryIsAbove
-                        ? primaryWrapper
-                        : root.secondarySource
+                Loader {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    active: root.showPrimary && root.showSecondary
+                    sourceComponent: root.secondaryIsAbove ? primaryWrapper : root.secondarySource
+                }
             }
         }
     }
 
     Component {
         id: primaryWrapper
-
         Rectangle {
             color: Appearance.colors.colPrimary
             radius: Appearance.rounding.full
-
-            implicitWidth:
-                pill.width - root.primaryPadding
-
-            implicitHeight:
-                root.primaryIsCircle && !root.swapPrimaryWithSecondary
-                    ? implicitWidth
-                    : (content.item ? content.item.implicitHeight : 0)
-                        + root.primaryPadding * 2
-                        + root.primaryHeightOffset
-
+            implicitWidth: pill.width - root.primaryPadding
+            implicitHeight: root.primaryIsCircle && root.secondaryIsCircleWhenAlone ? implicitWidth
+                                                                                   : (content.item ? content.item.implicitHeight : 0)
+                                                                                   + root.primaryPadding * 2 + root.primaryHeightOffset
             width: implicitWidth
             height: implicitHeight
-
             Loader {
                 id: content
-
                 anchors.centerIn: parent
-
-                sourceComponent:
-                    root.primarySource
+                sourceComponent: root.primarySource
             }
         }
     }


### PR DESCRIPTION
## Describe your changes

Makes secondary component circled when primary is hidden for material bar style. Also changed battery margin and code formatting to be more readable in `MaterialBarWidgets`

## Is it ready? Questions/feedback needed?

Tested for all possible layouts. Just a small adjustment so it's not a big deal