### PR TITLE
fix(fedora): harden Matugen and hyprmon requirements

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -21,7 +21,7 @@ It aims to provide a state-of-the-art Linux desktop experience by strictly adher
 - **Matugen 4.1.0 or newer**
 
 > [!NOTE]
-> Matugen **4.1.0+ is the supported/recommended version**. The lightweight scheme-switching path still detects Matugen 3 and avoids the Matugen 4-only `--source-color-index` option so an older installation fails gracefully instead of breaking scheme changes. On Fedora, the installer enables `avengemedia/danklinux` to source the current Matugen package.
+> Matugen **4.1.0+ is the supported/recommended version**. The lightweight scheme-switching path still detects Matugen 3 and avoids the Matugen 4-only `--source-color-index` option, preserving scheme changes on older installations. On Fedora, the installer enables `avengemedia/danklinux` to source the current Matugen package.
 
 ## Installation
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -15,6 +15,14 @@ It aims to provide a state-of-the-art Linux desktop experience by strictly adher
 > [!NOTE]
 > This repository is a work in progress. Some modules, like the Gmail client, require manual setup of API keys.
 
+## Requirements
+
+- **Hyprland 0.56.1 or newer**
+- **Matugen 4.1.0 or newer**
+
+> [!NOTE]
+> Matugen **4.1.0+ is the supported/recommended version**. The lightweight scheme-switching path still detects Matugen 3 and avoids the Matugen 4-only `--source-color-index` option so an older installation fails gracefully instead of breaking scheme changes. On Fedora, the installer enables `avengemedia/danklinux` to source the current Matugen package.
+
 ## Installation
 
 ### Default installation

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ A powerful and flexible environment manager for [ii-vynx](https://github.com/vag
 
 ---
 
+## ✅ Requirements
+
+- **Hyprland 0.56.1 or newer**
+- **Matugen 4.1.0 or newer**
+
+> [!NOTE]
+> The lightweight scheme-switching path keeps compatibility with Matugen 3 by detecting whether `--source-color-index` is available, but Matugen **4.1.0+ is the supported/recommended version**. On Fedora, the installer enables the `avengemedia/danklinux` COPR so `matugen` is sourced from the repository that provides the 4.x release instead of Fedora 44's older 3.x package.
+
+---
+
 ## 🚀 Installation
 
 To install **ii-vynx** and set up the management environment, clone this repository and run the setup script:

--- a/dots/.config/quickshell/ii/scripts/colors/apply_scheme_core.sh
+++ b/dots/.config/quickshell/ii/scripts/colors/apply_scheme_core.sh
@@ -106,7 +106,14 @@ matugen_args=()
 if [[ "$accent" =~ ^#?[A-Fa-f0-9]{6}$ ]]; then
     matugen_args=(color hex "$accent")
 elif [[ -n "$source_image" && -f "$source_image" ]]; then
-    matugen_args=(image "$source_image" --source-color-index 0)
+    matugen_args=(image "$source_image")
+
+    # Matugen 4 introduced interactive source-color selection for images.
+    # Matugen 3 automatically uses its ranked source color and does not accept
+    # --source-color-index, so only add the flag when the installed CLI exposes it.
+    if matugen image --help 2>&1 | grep -qF -- '--source-color-index'; then
+        matugen_args+=(--source-color-index 0)
+    fi
 else
     echo "[apply_scheme_core] No valid wallpaper/accent source available" >&2
     exit 1

--- a/sdata/dist-fedora/feddeps.toml
+++ b/sdata/dist-fedora/feddeps.toml
@@ -4,6 +4,7 @@
 repos = [
   "ririko66z/dots-hyprland",
   "sdegler/hyprland",
+  "avengemedia/danklinux",
   "deltacopy/darkly",
   "alternateved/eza",
   "atim/starship"

--- a/sdata/dist-fedora/install-deps.sh
+++ b/sdata/dist-fedora/install-deps.sh
@@ -60,6 +60,51 @@ function install_RPMS() {
   x cd ${REPO_ROOT}
 }
 
+function install_hyprmon() {
+  local release_api="https://api.github.com/repos/erans/hyprmon/releases/latest"
+  local machine_arch asset_name download_url tmp_dir binary_name
+
+  case "$(uname -m)" in
+    x86_64)
+      machine_arch="amd64"
+      ;;
+    aarch64|arm64)
+      machine_arch="arm64"
+      ;;
+    *)
+      echo "Unsupported architecture for hyprmon: $(uname -m)" >&2
+      return 1
+      ;;
+  esac
+
+  asset_name="hyprmon-linux-${machine_arch}.tar.gz"
+  download_url=$(curl -fsSL "$release_api" \
+    | jq -r --arg asset "$asset_name" '.assets[] | select(.name == $asset) | .browser_download_url' \
+    | head -n 1)
+
+  if [[ -z "$download_url" || "$download_url" == "null" ]]; then
+    echo "Could not resolve the latest hyprmon release asset: $asset_name" >&2
+    return 1
+  fi
+
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rf "$tmp_dir"' RETURN
+
+  curl -fL "$download_url" -o "$tmp_dir/$asset_name"
+  tar -xzf "$tmp_dir/$asset_name" -C "$tmp_dir"
+
+  binary_name="hyprmon-linux-${machine_arch}"
+  if [[ ! -f "$tmp_dir/$binary_name" ]]; then
+    echo "hyprmon release archive did not contain $binary_name" >&2
+    return 1
+  fi
+
+  mkdir -p "$HOME/.local/bin"
+  install -m 0755 "$tmp_dir/$binary_name" "$HOME/.local/bin/hyprmon"
+
+  "$HOME/.local/bin/hyprmon" --help >/dev/null 2>&1 || true
+}
+
 # -------------------------
 # MAIN
 # -------------------------
@@ -113,9 +158,11 @@ done < <(echo "$deps_data" | yq '.groups | keys[]? | select(length > 0)')
 # Add back versionlock at the end
 [ -n $nolock_qs ] || v sudo dnf versionlock add quickshell-git || true
 
-# Install hyprmon since no RPM is available
-echo "Installing hyprmon via go install..."
-env GOBIN=$HOME/.local/bin go install github.com/erans/hyprmon@latest
+# HyprMon's current go.mod declares the module path as "hyprmon", so
+# `go install github.com/erans/hyprmon@latest` fails with a module-path conflict.
+# Use the upstream release binary instead; upstream publishes amd64/arm64 assets.
+echo "Installing hyprmon from the latest upstream release..."
+install_hyprmon
 
 echo -e "\n========================================"
 echo "All installations are completed."


### PR DESCRIPTION
## Summary

- make the lightweight scheme apply path compatible with Matugen 3 by only passing `--source-color-index 0` when the installed Matugen CLI exposes that option
- document Hyprland `0.56.1+` and Matugen `4.1.0+` as supported runtime requirements
- enable the `avengemedia/danklinux` COPR on Fedora so `matugen` can resolve to the current 4.x package instead of Fedora 44's older package
- replace the broken Fedora `go install github.com/erans/hyprmon@latest` path with installation from HyprMon's official latest-release binary assets for amd64/arm64

## Why

Fresh Fedora installs exposed two dependency issues:

1. Fedora 44 can leave users on Matugen 3.x, where `--source-color-index` is not accepted. The scheme-only helper now feature-detects that CLI option while keeping Matugen 4.1.0+ as the supported baseline.
2. HyprMon v0.0.17 declares its Go module as `module hyprmon`, so `go install github.com/erans/hyprmon@latest` fails with a module-path conflict. Upstream publishes Linux amd64 and arm64 release archives, so the Fedora installer now consumes those instead.

## Fedora dependency verification

- `feddeps.toml` now enables `avengemedia/danklinux` before installing the existing `matugen` package requirement.
- the existing `sdegler/hyprland` COPR remains the Hyprland source; the README now states the shell requires Hyprland 0.56.1 or newer.
- HyprMon no longer relies on an invalid Go module install command.

## Testing / validation

- reproduced the Matugen 3 failure on a clean secondary user and confirmed the failure is specifically the unsupported `--source-color-index` argument
- confirmed Matugen 4.1.0 works with the source-color selection path
- verified HyprMon's upstream `go.mod` and v0.0.17 release assets before changing the Fedora installer
