### PR TITLE
perf: make preset switching cache-first and latest-wins

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/ConfigPresetsView.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/ConfigPresetsView.qml
@@ -20,20 +20,18 @@ ColumnLayout {
 
     Process {
         id: listPresetsProc
-        command: ["bash", "-c", `${Directories.scriptPath}/presets.sh list`]
+        command: [Directories.scriptPath + "/presets.sh", "list"]
         onRunningChanged: {
-            if (running) {
+            if (running)
                 presetsModel.clear();
-            }
         }
         stdout: SplitParser {
             onRead: data => {
-                let str = data.trim();
+                const str = data.trim();
                 if (!str)
                     return;
                 try {
-                    let obj = JSON.parse(str);
-                    presetsModel.append(obj);
+                    presetsModel.append(JSON.parse(str));
                 } catch (e) {
                     console.log("Failed to parse preset line:", e, str);
                 }
@@ -43,19 +41,16 @@ ColumnLayout {
 
     Process {
         id: importPresetProc
-        command: ["bash", "-c", `${Directories.scriptPath}/presets.sh import`]
+        command: [Directories.scriptPath + "/presets.sh", "import"]
         stdout: SplitParser {
             onRead: data => {
-                if (data.trim() === "success") {
+                if (data.trim() === "success")
                     refreshTimer.restart();
-                }
             }
         }
     }
 
-    Component.onCompleted: {
-        listPresetsProc.running = true;
-    }
+    Component.onCompleted: listPresetsProc.running = true
 
     ConfigRow {
         Layout.fillWidth: true
@@ -77,9 +72,10 @@ ColumnLayout {
             bottomLeftRadius: Appearance.rounding.full
             bottomRightRadius: Appearance.rounding.small
             Layout.fillHeight: true
-            enabled: presetNameInput.text.length > 0
+            enabled: presetNameInput.text.trim().length > 0 && !PresetManager.applying
             onClicked: {
-                Quickshell.execDetached(["bash", "-c", `${Directories.scriptPath}/presets.sh save "${presetNameInput.text}"`]);
+                const presetName = presetNameInput.text.trim();
+                Quickshell.execDetached([Directories.scriptPath + "/presets.sh", "save", presetName]);
                 refreshTimer.restart();
                 presetNameInput.text = "";
             }
@@ -93,6 +89,7 @@ ColumnLayout {
             bottomLeftRadius: Appearance.rounding.small
             bottomRightRadius: Appearance.rounding.full
             Layout.fillHeight: true
+            enabled: !PresetManager.applying
             onClicked: {
                 importPresetProc.running = false;
                 importPresetProc.running = true;
@@ -102,7 +99,7 @@ ColumnLayout {
 
     Timer {
         id: refreshTimer
-        interval: 500
+        interval: 300
         onTriggered: listPresetsProc.running = true
     }
 
@@ -178,9 +175,8 @@ ColumnLayout {
                         colBackground: "transparent"
                         colBackgroundHover: "transparent"
                         colRipple: ColorUtils.transparentize(Appearance.colors.colPrimary, 0.8)
-                        onClicked: {
-                            Quickshell.execDetached(["bash", "-c", `${Directories.scriptPath}/presets.sh load "${model.name}"`]);
-                        }
+                        enabled: !PresetManager.applying
+                        onClicked: PresetManager.apply(String(model.name))
                     }
 
                     ColumnLayout {
@@ -225,30 +221,31 @@ ColumnLayout {
                             }
 
                             RippleButton {
-                                    id: updateButton
-                                    anchors.right: exportButton.left
-                                    anchors.rightMargin: 5
-                                    anchors.verticalCenter: parent.verticalCenter
-                                    implicitWidth: 30
-                                    implicitHeight: 30
-                                    buttonRadius: Appearance.rounding.full
-                                    colBackground: Appearance.colors.colTertiaryContainer
-                                    colBackgroundHover: Appearance.colors.colTertiaryContainerHover
-                                    colRipple: Appearance.colors.colTertiaryContainerActive
+                                id: updateButton
+                                anchors.right: exportButton.left
+                                anchors.rightMargin: 5
+                                anchors.verticalCenter: parent.verticalCenter
+                                implicitWidth: 30
+                                implicitHeight: 30
+                                buttonRadius: Appearance.rounding.full
+                                colBackground: Appearance.colors.colTertiaryContainer
+                                colBackgroundHover: Appearance.colors.colTertiaryContainerHover
+                                colRipple: Appearance.colors.colTertiaryContainerActive
+                                enabled: !PresetManager.applying
 
-                                    contentItem: MaterialSymbol {
+                                contentItem: MaterialSymbol {
                                     anchors.centerIn: parent
                                     text: "save"
                                     iconSize: 16
                                     color: Appearance.colors.colOnTertiaryContainer
                                 }
 
-                                    onClicked: {
-                                    Quickshell.execDetached(["bash", "-c", `${Directories.scriptPath}/presets.sh update "${model.name}"`]);
+                                onClicked: {
+                                    Quickshell.execDetached([Directories.scriptPath + "/presets.sh", "update", String(model.name)]);
                                     refreshTimer.restart();
                                 }
 
-                                    StyledToolTip {
+                                StyledToolTip {
                                     text: Translation.tr("Save settings to this preset")
                                 }
                             }
@@ -263,6 +260,7 @@ ColumnLayout {
                                 colBackground: Appearance.colors.colError
                                 colBackgroundHover: Appearance.colors.colErrorHover
                                 colRipple: Appearance.colors.colErrorActive
+                                enabled: !PresetManager.applying
 
                                 contentItem: MaterialSymbol {
                                     anchors.centerIn: parent
@@ -272,7 +270,7 @@ ColumnLayout {
                                 }
 
                                 onClicked: {
-                                    Quickshell.execDetached(["bash", "-c", `${Directories.scriptPath}/presets.sh delete "${model.name}"`]);
+                                    Quickshell.execDetached([Directories.scriptPath + "/presets.sh", "delete", String(model.name)]);
                                     refreshTimer.restart();
                                 }
 
@@ -292,6 +290,7 @@ ColumnLayout {
                                 colBackground: Appearance.colors.colPrimaryContainer
                                 colBackgroundHover: Appearance.colors.colPrimaryContainerHover
                                 colRipple: Appearance.colors.colPrimaryContainerActive
+                                enabled: !PresetManager.applying
 
                                 contentItem: MaterialSymbol {
                                     anchors.centerIn: parent
@@ -300,9 +299,7 @@ ColumnLayout {
                                     color: Appearance.colors.colOnPrimaryContainer
                                 }
 
-                                onClicked: {
-                                    Quickshell.execDetached([Directories.scriptPath + "/presets.sh", "export", String(model.name)]);
-                                }
+                                onClicked: Quickshell.execDetached([Directories.scriptPath + "/presets.sh", "export", String(model.name)])
 
                                 StyledToolTip {
                                     text: Translation.tr("Export preset")

--- a/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
+++ b/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
@@ -10,6 +10,7 @@ XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
 XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 CONFIG_DIR="$XDG_CONFIG_HOME/quickshell/ii"
 CONFIG_FILE="$XDG_CONFIG_HOME/illogical-impulse/config.json"
+PRESETS_DIR="$XDG_CONFIG_HOME/illogical-impulse/presets"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COLOR_DIR="$SCRIPT_DIR/colors"
 GENERATED_DIR="$XDG_STATE_HOME/quickshell/user/generated"
@@ -137,6 +138,12 @@ wallpaper=$(jq -r '.background.wallpaperPath // ""' "$CONFIG_FILE" 2>/dev/null)
 use_wpe=$(jq -r '.background.useWallpaperEngine // false' "$CONFIG_FILE" 2>/dev/null)
 accent=$(jq -r '.appearance.palette.accentColor // ""' "$CONFIG_FILE" 2>/dev/null)
 scheme=$(jq -r '.appearance.palette.type // "auto"' "$CONFIG_FILE" 2>/dev/null)
+color_engine=$(jq -r '.appearance.colorEngine // "vynx"' "$CONFIG_FILE" 2>/dev/null)
+
+material_generator="$COLOR_DIR/generate_colors_material.py"
+if [[ "$color_engine" == "fork" ]]; then
+    material_generator="$COLOR_DIR/generate_colors_material_vynx.py"
+fi
 
 current_dark=$(jq -r '.darkmode // empty' "$COLORS_FILE" 2>/dev/null)
 if [[ "$current_dark" == "true" ]]; then
@@ -217,7 +224,13 @@ if [[ -n "$custom_theme" ]]; then
     fi
     atomic_copy "$custom_theme" "$COLORS_FILE" || exit 1
 else
-    matugen_args+=(--mode "$mode" --type "$scheme")
+    matugen_scheme="$scheme"
+    # The fork backend intentionally asks Matugen for fidelity and applies the
+    # intense surface boost afterwards; mirror switchwall_vynx.sh exactly.
+    if [[ "$color_engine" == "fork" && "$scheme" == "scheme-intense" ]]; then
+        matugen_scheme="scheme-fidelity"
+    fi
+    matugen_args+=(--mode "$mode" --type "$matugen_scheme")
     matugen "${matugen_args[@]}" >/dev/null 2>&1 || exit 1
     is_current_request || exit 0
 
@@ -228,7 +241,7 @@ fi
 
 is_current_request || exit 0
 
-if [[ -z "$custom_theme" && -f "$TERMSCHEME" ]]; then
+if [[ -z "$custom_theme" && -f "$TERMSCHEME" && -f "$material_generator" ]]; then
     force_dark=$(jq -r '.appearance.wallpaperTheming.terminalGenerationProps.forceDarkMode // false' "$CONFIG_FILE" 2>/dev/null)
     if [[ "$force_dark" == "true" ]]; then
         generate_args+=(--mode dark)
@@ -248,7 +261,7 @@ if [[ -z "$custom_theme" && -f "$TERMSCHEME" ]]; then
     python_bin="python3"
     [[ -x "$venv/bin/python" ]] && python_bin="$venv/bin/python"
     scss_tmp="${SCSS_FILE}.preset.$$"
-    if "$python_bin" "$COLOR_DIR/generate_colors_material.py" "${generate_args[@]}" > "$scss_tmp"; then
+    if "$python_bin" "$material_generator" "${generate_args[@]}" > "$scss_tmp"; then
         if is_current_request; then
             mv -f -- "$scss_tmp" "$SCSS_FILE"
         else
@@ -264,5 +277,10 @@ is_current_request || exit 0
 atomic_copy "$COLORS_FILE" "$cache_dir/colors.json" || true
 atomic_copy "$SCSS_FILE" "$cache_dir/material_colors.scss" || true
 printf '%s\n' "$preset_name" > "$cache_dir/name"
+
+preset_file="$PRESETS_DIR/$preset_name.json"
+if [[ -f "$preset_file" ]]; then
+    sha256sum -- "$preset_file" | cut -d' ' -f1 > "$cache_dir/config.sha256"
+fi
 
 bash "$SCRIPT_DIR/preset_post_apply.sh" "$request_id" "$token_file" >/dev/null 2>&1 &

--- a/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
+++ b/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+preset_name="${1:-}"
+request_id="${2:-}"
+token_file="${3:-}"
+cache_dir="${4:-}"
+
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+CONFIG_DIR="$XDG_CONFIG_HOME/quickshell/ii"
+CONFIG_FILE="$XDG_CONFIG_HOME/illogical-impulse/config.json"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COLOR_DIR="$SCRIPT_DIR/colors"
+GENERATED_DIR="$XDG_STATE_HOME/quickshell/user/generated"
+COLORS_FILE="$GENERATED_DIR/colors.json"
+SCSS_FILE="$GENERATED_DIR/material_colors.scss"
+TERMSCHEME="$COLOR_DIR/terminal/scheme-base.json"
+
+is_current_request() {
+    [[ -n "$request_id" && -n "$token_file" && -f "$token_file" ]] || return 1
+    [[ "$(cat -- "$token_file" 2>/dev/null)" == "$request_id" ]]
+}
+
+atomic_copy() {
+    local src="$1"
+    local dst="$2"
+    local tmp="${dst}.tmp.$$"
+    [[ -f "$src" ]] || return 1
+    mkdir -p "$(dirname -- "$dst")"
+    cp -- "$src" "$tmp" || return 1
+    mv -f -- "$tmp" "$dst"
+}
+
+is_current_request || exit 0
+[[ -f "$CONFIG_FILE" ]] || exit 1
+mkdir -p "$GENERATED_DIR" "$cache_dir"
+
+enable_apps=$(jq -r '.appearance.wallpaperTheming.enableAppsAndShell // true' "$CONFIG_FILE" 2>/dev/null)
+[[ "$enable_apps" == "true" ]] || exit 0
+
+wallpaper=$(jq -r '.background.wallpaperPath // ""' "$CONFIG_FILE" 2>/dev/null)
+accent=$(jq -r '.appearance.palette.accentColor // ""' "$CONFIG_FILE" 2>/dev/null)
+scheme=$(jq -r '.appearance.palette.type // "auto"' "$CONFIG_FILE" 2>/dev/null)
+
+current_dark=$(jq -r '.darkmode // empty' "$COLORS_FILE" 2>/dev/null)
+if [[ "$current_dark" == "true" ]]; then
+    mode="dark"
+elif [[ "$current_dark" == "false" ]]; then
+    mode="light"
+else
+    current_mode=$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'")
+    if [[ "$current_mode" == "prefer-dark" ]]; then
+        mode="dark"
+    else
+        mode="light"
+    fi
+fi
+
+matugen_args=(--source-color-index 0)
+generate_args=()
+
+if [[ "$accent" =~ ^#?[A-Fa-f0-9]{6}$ ]]; then
+    matugen_args+=(color hex "$accent")
+    generate_args+=(--color "$accent")
+else
+    if [[ ! -f "$wallpaper" ]]; then
+        exit 0
+    fi
+    matugen_args+=(image "$wallpaper")
+    generate_args+=(--path "$wallpaper")
+fi
+
+allowed_scheme=0
+case "$scheme" in
+    scheme-content|scheme-expressive|scheme-fidelity|scheme-fruit-salad|scheme-monochrome|scheme-neutral|scheme-rainbow|scheme-tonal-spot|scheme-vibrant|scheme-intense)
+        allowed_scheme=1
+        ;;
+    auto|scheme-auto)
+        if [[ -f "$wallpaper" ]]; then
+            venv="${ILLOGICAL_IMPULSE_VIRTUAL_ENV:-$XDG_STATE_HOME/quickshell/.venv}"
+            if [[ -x "$venv/bin/python" ]]; then
+                detected=$("$venv/bin/python" "$COLOR_DIR/scheme_for_image.py" "$wallpaper" 2>/dev/null | tr -d '\n')
+                case "$detected" in
+                    scheme-content|scheme-expressive|scheme-fidelity|scheme-fruit-salad|scheme-monochrome|scheme-neutral|scheme-rainbow|scheme-tonal-spot|scheme-vibrant)
+                        scheme="$detected"
+                        ;;
+                    *)
+                        scheme="scheme-tonal-spot"
+                        ;;
+                esac
+            else
+                scheme="scheme-tonal-spot"
+            fi
+        else
+            scheme="scheme-tonal-spot"
+        fi
+        allowed_scheme=1
+        ;;
+    *)
+        ;;
+esac
+
+custom_theme=""
+if [[ $allowed_scheme -eq 0 ]]; then
+    if [[ -f "$XDG_CONFIG_HOME/illogical-impulse/themes/$scheme.json" ]]; then
+        custom_theme="$XDG_CONFIG_HOME/illogical-impulse/themes/$scheme.json"
+    elif [[ -f "$CONFIG_DIR/defaults/themes/$scheme.json" ]]; then
+        custom_theme="$CONFIG_DIR/defaults/themes/$scheme.json"
+    else
+        scheme="scheme-tonal-spot"
+    fi
+fi
+
+is_current_request || exit 0
+
+if [[ -n "$custom_theme" ]]; then
+    if [[ "$mode" == "light" && -f "${custom_theme%.json}_light.json" ]]; then
+        custom_theme="${custom_theme%.json}_light.json"
+    fi
+    atomic_copy "$custom_theme" "$COLORS_FILE" || exit 1
+else
+    matugen_args+=(--mode "$mode" --type "$scheme")
+    matugen "${matugen_args[@]}" >/dev/null 2>&1 || exit 1
+    is_current_request || exit 0
+
+    if [[ "$scheme" == "scheme-intense" && -f "$COLOR_DIR/boost_surface_chroma.py" ]]; then
+        python3 "$COLOR_DIR/boost_surface_chroma.py" "$COLORS_FILE" --mode "$mode" >/dev/null 2>&1 || true
+    fi
+fi
+
+is_current_request || exit 0
+
+if [[ -z "$custom_theme" && -f "$TERMSCHEME" ]]; then
+    force_dark=$(jq -r '.appearance.wallpaperTheming.terminalGenerationProps.forceDarkMode // false' "$CONFIG_FILE" 2>/dev/null)
+    if [[ "$force_dark" == "true" ]]; then
+        generate_args+=(--mode dark)
+    else
+        generate_args+=(--mode "$mode")
+    fi
+    generate_args+=(--scheme "$scheme" --termscheme "$TERMSCHEME" --blend_bg_fg --cache "$GENERATED_DIR/color.txt")
+
+    harmony=$(jq -r '.appearance.wallpaperTheming.terminalGenerationProps.harmony // empty' "$CONFIG_FILE" 2>/dev/null)
+    threshold=$(jq -r '.appearance.wallpaperTheming.terminalGenerationProps.harmonizeThreshold // empty' "$CONFIG_FILE" 2>/dev/null)
+    fg_boost=$(jq -r '.appearance.wallpaperTheming.terminalGenerationProps.termFgBoost // empty' "$CONFIG_FILE" 2>/dev/null)
+    [[ -n "$harmony" ]] && generate_args+=(--harmony "$harmony")
+    [[ -n "$threshold" ]] && generate_args+=(--harmonize_threshold "$threshold")
+    [[ -n "$fg_boost" ]] && generate_args+=(--term_fg_boost "$fg_boost")
+
+    venv="${ILLOGICAL_IMPULSE_VIRTUAL_ENV:-$XDG_STATE_HOME/quickshell/.venv}"
+    python_bin="python3"
+    [[ -x "$venv/bin/python" ]] && python_bin="$venv/bin/python"
+    scss_tmp="${SCSS_FILE}.preset.$$"
+    if "$python_bin" "$COLOR_DIR/generate_colors_material.py" "${generate_args[@]}" > "$scss_tmp"; then
+        if is_current_request; then
+            mv -f -- "$scss_tmp" "$SCSS_FILE"
+        else
+            rm -f -- "$scss_tmp"
+            exit 0
+        fi
+    else
+        rm -f -- "$scss_tmp"
+    fi
+fi
+
+is_current_request || exit 0
+atomic_copy "$COLORS_FILE" "$cache_dir/colors.json" || true
+atomic_copy "$SCSS_FILE" "$cache_dir/material_colors.scss" || true
+printf '%s\n' "$preset_name" > "$cache_dir/name"
+
+"$SCRIPT_DIR/preset_post_apply.sh" "$request_id" "$token_file" >/dev/null 2>&1 &

--- a/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
+++ b/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
@@ -16,10 +16,11 @@ GENERATED_DIR="$XDG_STATE_HOME/quickshell/user/generated"
 COLORS_FILE="$GENERATED_DIR/colors.json"
 SCSS_FILE="$GENERATED_DIR/material_colors.scss"
 TERMSCHEME="$COLOR_DIR/terminal/scheme-base.json"
-TEMP_SOURCE=""
+WPE_TEMP_SOURCE="/tmp/ii-preset-wpe-${request_id}.png"
+VIDEO_TEMP_SOURCE="/tmp/ii-preset-video-${request_id}.jpg"
 
 cleanup() {
-    [[ -z "$TEMP_SOURCE" ]] || rm -f -- "$TEMP_SOURCE"
+    rm -f -- "$WPE_TEMP_SOURCE" "$VIDEO_TEMP_SOURCE"
 }
 trap cleanup EXIT
 
@@ -76,12 +77,9 @@ resolve_wpe_preview() {
             return 0
         fi
         candidate="$workshop/$wpe_id/preview.gif"
-        if [[ -f "$candidate" ]]; then
-            TEMP_SOURCE="/tmp/ii-preset-wpe-${request_id}.png"
-            if extract_first_frame "$candidate" "$TEMP_SOURCE"; then
-                printf '%s' "$TEMP_SOURCE"
-                return 0
-            fi
+        if [[ -f "$candidate" ]] && extract_first_frame "$candidate" "$WPE_TEMP_SOURCE"; then
+            printf '%s' "$WPE_TEMP_SOURCE"
+            return 0
         fi
     done
     return 1
@@ -110,9 +108,8 @@ resolve_color_source() {
                 return 0
             fi
             [[ -f "$wallpaper" ]] || return 1
-            TEMP_SOURCE="/tmp/ii-preset-video-${request_id}.jpg"
-            extract_first_frame "$wallpaper" "$TEMP_SOURCE" || return 1
-            printf '%s' "$TEMP_SOURCE"
+            extract_first_frame "$wallpaper" "$VIDEO_TEMP_SOURCE" || return 1
+            printf '%s' "$VIDEO_TEMP_SOURCE"
             return 0
             ;;
         *)

--- a/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
+++ b/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
@@ -16,6 +16,12 @@ GENERATED_DIR="$XDG_STATE_HOME/quickshell/user/generated"
 COLORS_FILE="$GENERATED_DIR/colors.json"
 SCSS_FILE="$GENERATED_DIR/material_colors.scss"
 TERMSCHEME="$COLOR_DIR/terminal/scheme-base.json"
+TEMP_SOURCE=""
+
+cleanup() {
+    [[ -z "$TEMP_SOURCE" ]] || rm -f -- "$TEMP_SOURCE"
+}
+trap cleanup EXIT
 
 is_current_request() {
     [[ -n "$request_id" && -n "$token_file" && -f "$token_file" ]] || return 1
@@ -32,6 +38,91 @@ atomic_copy() {
     mv -f -- "$tmp" "$dst"
 }
 
+extract_first_frame() {
+    local input="$1"
+    local output="$2"
+    command -v ffmpeg >/dev/null 2>&1 || return 1
+    ffmpeg -loglevel error -y -i "$input" -frames:v 1 "$output" >/dev/null 2>&1
+}
+
+resolve_wpe_preview() {
+    local wpe_id="$1"
+    local assets="$2"
+    local candidate workshop
+    local -a workshops=()
+
+    if [[ -n "$assets" ]]; then
+        workshop="${assets/common\/wallpaper_engine\/assets/workshop\/content\/431960}"
+        workshops+=("$workshop")
+        workshop="${assets/common\/wallpaper_engine/workshop\/content\/431960}"
+        workshops+=("$workshop")
+    fi
+    workshops+=(
+        "$HOME/.local/share/Steam/steamapps/workshop/content/431960"
+        "$HOME/.steam/steam/steamapps/workshop/content/431960"
+        "$HOME/.steam/root/steamapps/workshop/content/431960"
+    )
+
+    for workshop in "${workshops[@]}"; do
+        [[ -d "$workshop/$wpe_id" ]] || continue
+        candidate="$workshop/$wpe_id/preview.jpg"
+        if [[ -f "$candidate" ]]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+        candidate="$workshop/$wpe_id/preview.png"
+        if [[ -f "$candidate" ]]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+        candidate="$workshop/$wpe_id/preview.gif"
+        if [[ -f "$candidate" ]]; then
+            TEMP_SOURCE="/tmp/ii-preset-wpe-${request_id}.png"
+            if extract_first_frame "$candidate" "$TEMP_SOURCE"; then
+                printf '%s' "$TEMP_SOURCE"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+resolve_color_source() {
+    local wallpaper="$1"
+    local use_wpe="$2"
+    local thumbnail source wpe_id wpe_assets
+
+    if [[ "$use_wpe" == "true" ]]; then
+        wpe_id=$(jq -r '.background.wallpaperEngineId // ""' "$CONFIG_FILE" 2>/dev/null)
+        wpe_assets=$(jq -r '.background.wallpaperEngineAssetsPath // ""' "$CONFIG_FILE" 2>/dev/null)
+        if [[ -n "$wpe_id" ]] && source=$(resolve_wpe_preview "$wpe_id" "$wpe_assets"); then
+            printf '%s' "$source"
+            return 0
+        fi
+        return 1
+    fi
+
+    case "${wallpaper,,}" in
+        *.mp4|*.mkv|*.webm|*.avi|*.mov|*.m4v|*.ogv)
+            thumbnail=$(jq -r '.background.thumbnailPath // ""' "$CONFIG_FILE" 2>/dev/null)
+            if [[ -f "$thumbnail" ]]; then
+                printf '%s' "$thumbnail"
+                return 0
+            fi
+            [[ -f "$wallpaper" ]] || return 1
+            TEMP_SOURCE="/tmp/ii-preset-video-${request_id}.jpg"
+            extract_first_frame "$wallpaper" "$TEMP_SOURCE" || return 1
+            printf '%s' "$TEMP_SOURCE"
+            return 0
+            ;;
+        *)
+            [[ -f "$wallpaper" ]] || return 1
+            printf '%s' "$wallpaper"
+            return 0
+            ;;
+    esac
+}
+
 is_current_request || exit 0
 [[ -f "$CONFIG_FILE" ]] || exit 1
 mkdir -p "$GENERATED_DIR" "$cache_dir"
@@ -46,6 +137,7 @@ enable_apps=$(jq -r '.appearance.wallpaperTheming.enableAppsAndShell // true' "$
 [[ "$enable_apps" == "true" ]] || exit 0
 
 wallpaper=$(jq -r '.background.wallpaperPath // ""' "$CONFIG_FILE" 2>/dev/null)
+use_wpe=$(jq -r '.background.useWallpaperEngine // false' "$CONFIG_FILE" 2>/dev/null)
 accent=$(jq -r '.appearance.palette.accentColor // ""' "$CONFIG_FILE" 2>/dev/null)
 scheme=$(jq -r '.appearance.palette.type // "auto"' "$CONFIG_FILE" 2>/dev/null)
 
@@ -65,16 +157,18 @@ fi
 
 matugen_args=(--source-color-index 0)
 generate_args=()
+color_source=""
 
 if [[ "$accent" =~ ^#?[A-Fa-f0-9]{6}$ ]]; then
     matugen_args+=(color hex "$accent")
     generate_args+=(--color "$accent")
 else
-    if [[ ! -f "$wallpaper" ]]; then
-        exit 0
-    fi
-    matugen_args+=(image "$wallpaper")
-    generate_args+=(--path "$wallpaper")
+    # WPE/video presets need an image preview. Never feed a video or unrelated
+    # stale wallpaperPath directly into Matugen: if a safe source cannot be
+    # resolved, preserve the current palette and simply leave this preset cold.
+    color_source=$(resolve_color_source "$wallpaper" "$use_wpe") || exit 0
+    matugen_args+=(image "$color_source")
+    generate_args+=(--path "$color_source")
 fi
 
 allowed_scheme=0
@@ -83,10 +177,10 @@ case "$scheme" in
         allowed_scheme=1
         ;;
     auto|scheme-auto)
-        if [[ -f "$wallpaper" ]]; then
+        if [[ -n "$color_source" && -f "$color_source" ]]; then
             venv="${ILLOGICAL_IMPULSE_VIRTUAL_ENV:-$XDG_STATE_HOME/quickshell/.venv}"
             if [[ -x "$venv/bin/python" ]]; then
-                detected=$("$venv/bin/python" "$COLOR_DIR/scheme_for_image.py" "$wallpaper" 2>/dev/null | tr -d '\n')
+                detected=$("$venv/bin/python" "$COLOR_DIR/scheme_for_image.py" "$color_source" 2>/dev/null | tr -d '\n')
                 case "$detected" in
                     scheme-content|scheme-expressive|scheme-fidelity|scheme-fruit-salad|scheme-monochrome|scheme-neutral|scheme-rainbow|scheme-tonal-spot|scheme-vibrant)
                         scheme="$detected"

--- a/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
+++ b/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
@@ -36,6 +36,12 @@ is_current_request || exit 0
 [[ -f "$CONFIG_FILE" ]] || exit 1
 mkdir -p "$GENERATED_DIR" "$cache_dir"
 
+# An uncached legacy/imported preset already committed its config. Give
+# Quickshell/compositor one frame before starting CPU-heavy color generation so
+# first-use fallback cannot steal time from the visible transition.
+sleep 0.12
+is_current_request || exit 0
+
 enable_apps=$(jq -r '.appearance.wallpaperTheming.enableAppsAndShell // true' "$CONFIG_FILE" 2>/dev/null)
 [[ "$enable_apps" == "true" ]] || exit 0
 

--- a/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
+++ b/dots/.config/quickshell/ii/scripts/preset_generate_theme.sh
@@ -168,4 +168,4 @@ atomic_copy "$COLORS_FILE" "$cache_dir/colors.json" || true
 atomic_copy "$SCSS_FILE" "$cache_dir/material_colors.scss" || true
 printf '%s\n' "$preset_name" > "$cache_dir/name"
 
-"$SCRIPT_DIR/preset_post_apply.sh" "$request_id" "$token_file" >/dev/null 2>&1 &
+bash "$SCRIPT_DIR/preset_post_apply.sh" "$request_id" "$token_file" >/dev/null 2>&1 &

--- a/dots/.config/quickshell/ii/scripts/preset_post_apply.sh
+++ b/dots/.config/quickshell/ii/scripts/preset_post_apply.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -u
+
+request_id="${1:-}"
+token_file="${2:-}"
+
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+CONFIG_FILE="$XDG_CONFIG_HOME/illogical-impulse/config.json"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GENERATED_DIR="$XDG_STATE_HOME/quickshell/user/generated"
+COLORS_FILE="$GENERATED_DIR/colors.json"
+
+is_current_request() {
+    [[ -z "$request_id" || -z "$token_file" ]] && return 0
+    [[ -f "$token_file" ]] || return 1
+    [[ "$(cat -- "$token_file" 2>/dev/null)" == "$request_id" ]]
+}
+
+is_current_request || exit 0
+
+# Yield the first render frame to Quickshell. Everything below is integration
+# work that does not need to block the shell's visual preset transition.
+sleep 0.12
+is_current_request || exit 0
+
+if [[ -f "$COLORS_FILE" ]]; then
+    darkmode=$(jq -r '.darkmode // empty' "$COLORS_FILE" 2>/dev/null)
+    if [[ "$darkmode" == "true" ]]; then
+        gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark' >/dev/null 2>&1 &
+        gsettings set org.gnome.desktop.interface gtk-theme 'adw-gtk3-dark' >/dev/null 2>&1 &
+    elif [[ "$darkmode" == "false" ]]; then
+        gsettings set org.gnome.desktop.interface color-scheme 'prefer-light' >/dev/null 2>&1 &
+        gsettings set org.gnome.desktop.interface gtk-theme 'adw-gtk3' >/dev/null 2>&1 &
+    fi
+fi
+
+# Terminal/OpenRGB application uses the already cached SCSS and is intentionally
+# detached from the visual transition.
+if [[ -f "$GENERATED_DIR/material_colors.scss" ]]; then
+    "$SCRIPT_DIR/colors/applycolor.sh" >/dev/null 2>&1 &
+fi
+
+is_current_request || exit 0
+
+enable_apps=$(jq -r '.appearance.wallpaperTheming.enableAppsAndShell // true' "$CONFIG_FILE" 2>/dev/null)
+if [[ "$enable_apps" != "true" ]]; then
+    exit 0
+fi
+
+# Lower-priority consumers are fan-out work. Run them concurrently only after
+# the shell has had time to paint the new preset.
+sleep 0.18
+is_current_request || exit 0
+
+if [[ -x "$SCRIPT_DIR/colors/code/material-code-set-color.sh" ]]; then
+    "$SCRIPT_DIR/colors/code/material-code-set-color.sh" >/dev/null 2>&1 &
+fi
+if [[ -x "$SCRIPT_DIR/ytmusic/generate-ytmusic-theme.sh" ]]; then
+    "$SCRIPT_DIR/ytmusic/generate-ytmusic-theme.sh" >/dev/null 2>&1 &
+fi
+if [[ -f "$SCRIPT_DIR/colors/recolor_icons.py" ]]; then
+    python3 "$SCRIPT_DIR/colors/recolor_icons.py" >/dev/null 2>&1 &
+fi
+
+enable_qt=$(jq -r '.appearance.wallpaperTheming.enableQtApps // true' "$CONFIG_FILE" 2>/dev/null)
+if [[ "$enable_qt" == "true" ]]; then
+    scheme=$(jq -r '.appearance.palette.type // "scheme-tonal-spot"' "$CONFIG_FILE" 2>/dev/null)
+    case "$scheme" in
+        scheme-content|scheme-expressive|scheme-fidelity|scheme-fruit-salad|scheme-monochrome|scheme-neutral|scheme-rainbow|scheme-tonal-spot|scheme-vibrant)
+            ;;
+        scheme-intense)
+            scheme="scheme-fidelity"
+            ;;
+        *)
+            scheme="scheme-tonal-spot"
+            ;;
+    esac
+    kde_wrapper="$XDG_CONFIG_HOME/matugen/templates/kde/kde-material-you-colors-wrapper.sh"
+    if [[ -x "$kde_wrapper" ]]; then
+        "$kde_wrapper" --scheme-variant "$scheme" >/dev/null 2>&1 &
+    fi
+fi

--- a/dots/.config/quickshell/ii/scripts/preset_post_apply.sh
+++ b/dots/.config/quickshell/ii/scripts/preset_post_apply.sh
@@ -36,9 +36,15 @@ if [[ -f "$COLORS_FILE" ]]; then
 fi
 
 # Terminal/OpenRGB application uses the already cached SCSS and is intentionally
-# detached from the visual transition.
-if [[ -f "$GENERATED_DIR/material_colors.scss" ]]; then
-    "$SCRIPT_DIR/colors/applycolor.sh" >/dev/null 2>&1 &
+# detached from the visual transition. Keep parity with the preset's selected
+# color engine instead of always using the default applycolor backend.
+color_engine=$(jq -r '.appearance.colorEngine // "vynx"' "$CONFIG_FILE" 2>/dev/null)
+applycolor_script="$SCRIPT_DIR/colors/applycolor.sh"
+if [[ "$color_engine" == "fork" ]]; then
+    applycolor_script="$SCRIPT_DIR/colors/applycolor_vynx.sh"
+fi
+if [[ -f "$GENERATED_DIR/material_colors.scss" && -f "$applycolor_script" ]]; then
+    bash "$applycolor_script" >/dev/null 2>&1 &
 fi
 
 is_current_request || exit 0

--- a/dots/.config/quickshell/ii/scripts/presets.sh
+++ b/dots/.config/quickshell/ii/scripts/presets.sh
@@ -1,9 +1,21 @@
 #!/usr/bin/env bash
+set -uo pipefail
 
 PRESETS_DIR="$HOME/.config/illogical-impulse/presets"
 CONFIG_FILE="$HOME/.config/illogical-impulse/config.json"
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-mkdir -p "$PRESETS_DIR"
+XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+GENERATED_DIR="$XDG_STATE_HOME/quickshell/user/generated"
+CACHE_ROOT="$PRESETS_DIR/.cache"
+TOKEN_FILE="$XDG_STATE_HOME/quickshell/user/preset_apply_request"
+STATUS_FILE="$XDG_STATE_HOME/quickshell/user/preset_apply_status"
+GENERATOR_PID_FILE="$XDG_STATE_HOME/quickshell/user/preset_theme_generator"
+
+mkdir -p "$PRESETS_DIR" "$CACHE_ROOT" "$GENERATED_DIR" "$(dirname "$TOKEN_FILE")"
+
+action="${1:-}"
+name="${2:-}"
+request_id="${3:-}"
 
 notify_export() {
     local urgency="$1"
@@ -21,141 +33,250 @@ fail_export() {
     exit 1
 }
 
-action=$1
-name=$2
+valid_name() {
+    [[ -n "$name" && "$name" != "." && "$name" != ".." ]] || return 1
+    [[ "$name" != *"/"* && "$name" != *$'\n'* && "$name" != *$'\r'* && "$name" != *$'\t'* ]] || return 1
+}
 
-case $action in
+cache_dir_for() {
+    local preset_name="$1"
+    local key
+    key=$(printf '%s' "$preset_name" | sha256sum | cut -d' ' -f1)
+    printf '%s/%s' "$CACHE_ROOT" "$key"
+}
+
+atomic_copy() {
+    local src="$1"
+    local dst="$2"
+    local tmp="${dst}.tmp.$$"
+    [[ -f "$src" ]] || return 1
+    mkdir -p "$(dirname -- "$dst")"
+    cp -- "$src" "$tmp" || return 1
+    mv -f -- "$tmp" "$dst"
+}
+
+cache_snapshot() {
+    local preset_name="$1"
+    local cache_dir
+    cache_dir=$(cache_dir_for "$preset_name")
+    mkdir -p "$cache_dir"
+    atomic_copy "$GENERATED_DIR/colors.json" "$cache_dir/colors.json" || true
+    atomic_copy "$GENERATED_DIR/material_colors.scss" "$cache_dir/material_colors.scss" || true
+    printf '%s\n' "$preset_name" > "$cache_dir/name"
+}
+
+restore_cached_theme() {
+    local preset_name="$1"
+    local cache_dir
+    cache_dir=$(cache_dir_for "$preset_name")
+    [[ -f "$cache_dir/colors.json" ]] || return 1
+
+    # Presets do not own the global light/dark mode. Reusing an exported cache
+    # from the opposite mode would emit darkmodeChanged and can recursively
+    # start another wallpaper pipeline. Warm a same-mode cache instead.
+    local cached_dark current_dark
+    cached_dark=$(jq -r '.darkmode // empty' "$cache_dir/colors.json" 2>/dev/null)
+    current_dark=$(jq -r '.darkmode // empty' "$GENERATED_DIR/colors.json" 2>/dev/null)
+    if [[ -n "$cached_dark" && -n "$current_dark" && "$cached_dark" != "$current_dark" ]]; then
+        return 1
+    fi
+
+    atomic_copy "$cache_dir/colors.json" "$GENERATED_DIR/colors.json" || return 1
+    if [[ -f "$cache_dir/material_colors.scss" ]]; then
+        atomic_copy "$cache_dir/material_colors.scss" "$GENERATED_DIR/material_colors.scss" || true
+    fi
+    return 0
+}
+
+register_request() {
+    [[ "$request_id" =~ ^[0-9]+$ ]] || request_id="$(date +%s%3N)"
+
+    exec 201>"${TOKEN_FILE}.lock"
+    flock -x 201
+    local current=""
+    [[ -f "$TOKEN_FILE" ]] && current=$(cat -- "$TOKEN_FILE" 2>/dev/null)
+    if [[ "$current" =~ ^[0-9]+$ ]] && (( request_id <= current )); then
+        flock -u 201
+        exec 201>&-
+        return 1
+    fi
+    printf '%s' "$request_id" > "${TOKEN_FILE}.tmp.$$"
+    mv -f -- "${TOKEN_FILE}.tmp.$$" "$TOKEN_FILE"
+    flock -u 201
+    exec 201>&-
+    return 0
+}
+
+is_current_request() {
+    [[ -f "$TOKEN_FILE" ]] || return 1
+    [[ "$(cat -- "$TOKEN_FILE" 2>/dev/null)" == "$request_id" ]]
+}
+
+write_status() {
+    local state="$1"
+    local mode="${2:-}"
+    is_current_request || return 0
+    local tmp="${STATUS_FILE}.tmp.$$"
+    printf '%s\t%s\t%s\n' "$request_id" "$state" "$mode" > "$tmp"
+    mv -f -- "$tmp" "$STATUS_FILE"
+}
+
+cancel_previous_generator() {
+    [[ -f "$GENERATOR_PID_FILE" ]] || return 0
+    local old_request old_pid
+    IFS=$'\t' read -r old_request old_pid < "$GENERATOR_PID_FILE" || true
+    if [[ "$old_pid" =~ ^[0-9]+$ && "$old_request" != "$request_id" ]]; then
+        kill -- "-$old_pid" >/dev/null 2>&1 || true
+        for _ in {1..10}; do
+            kill -0 "$old_pid" >/dev/null 2>&1 || break
+            sleep 0.01
+        done
+        kill -KILL -- "-$old_pid" >/dev/null 2>&1 || true
+    fi
+    rm -f -- "$GENERATOR_PID_FILE"
+}
+
+start_cache_warmup() {
+    local preset_name="$1"
+    local cache_dir
+    cache_dir=$(cache_dir_for "$preset_name")
+
+    setsid bash "$SCRIPTS_DIR/preset_generate_theme.sh" \
+        "$preset_name" "$request_id" "$TOKEN_FILE" "$cache_dir" \
+        > /tmp/presets_theme_warmup.log 2>&1 &
+    local generator_pid=$!
+    printf '%s\t%s\n' "$request_id" "$generator_pid" > "${GENERATOR_PID_FILE}.tmp.$$"
+    mv -f -- "${GENERATOR_PID_FILE}.tmp.$$" "$GENERATOR_PID_FILE"
+}
+
+case "$action" in
     save)
-        if [[ -z "$name" ]]; then exit 1; fi
-        cp "$CONFIG_FILE" "$PRESETS_DIR/$name.json"
-        
-        # Also copy the wallpaper if configured
+        valid_name || exit 1
+        cp -- "$CONFIG_FILE" "$PRESETS_DIR/$name.json" || exit 1
+
         wall_path=$(jq -r '.background.wallpaperPath // ""' "$CONFIG_FILE" 2>/dev/null)
         if [[ -f "$wall_path" ]]; then
             ext="${wall_path##*.}"
-            cp "$wall_path" "$PRESETS_DIR/$name.$ext"
+            cp -- "$wall_path" "$PRESETS_DIR/$name.$ext"
         fi
+        cache_snapshot "$name"
         ;;
-        update)
-    if [[ -z "$name" ]]; then exit 1; fi
-    if [[ ! -f "$PRESETS_DIR/$name.json" ]]; then exit 1; fi
-    # Remove stale wallpaper files for this preset before overwriting
-    for file in "$PRESETS_DIR/$name".*; do
-        if [[ -f "$file" && "${file##*.}" != "json" ]]; then
-            rm -f "$file"
-        fi
-    done
-    cp "$CONFIG_FILE" "$PRESETS_DIR/$name.json"
-    wall_path=$(jq -r '.background.wallpaperPath // ""' "$CONFIG_FILE" 2>/dev/null)
-    if [[ -f "$wall_path" ]]; then
-        ext="${wall_path##*.}"
-        cp "$wall_path" "$PRESETS_DIR/$name.$ext"
-    fi
-    ;;
-    load)
-        if [[ -z "$name" ]]; then exit 1; fi
-        if [[ -f "$PRESETS_DIR/$name.json" ]]; then
-            # Use python helper to expand paths and fallbacks
-            python3 "$SCRIPTS_DIR/presets_helper.py" expand "$PRESETS_DIR/$name.json" "$CONFIG_FILE" "$PRESETS_DIR" "$name"
-            
-            # Read colorEngine from the newly expanded config.json to run the correct script
-            color_engine=$(jq -r '.appearance.colorEngine // "vynx"' "$CONFIG_FILE" 2>/dev/null)
-            switch_script="switchwall.sh"
-            if [[ "$color_engine" == "fork" ]]; then
-                switch_script="switchwall_vynx.sh"
-            fi
-            
-            # Apply wallpaper and colors from the newly loaded config
-            env -u LD_LIBRARY_PATH -u PYTHONHOME -u PYTHONPATH PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH" "$SCRIPTS_DIR/colors/$switch_script" --noswitch > /tmp/presets_switchwall.log 2>&1 &
-        fi
-        ;;
-    delete)
-        if [[ -z "$name" ]]; then exit 1; fi
-        rm -f "$PRESETS_DIR/$name.json"
-        # Delete any associated wallpaper file
+
+    update)
+        valid_name || exit 1
+        [[ -f "$PRESETS_DIR/$name.json" ]] || exit 1
         for file in "$PRESETS_DIR/$name".*; do
             if [[ -f "$file" && "${file##*.}" != "json" ]]; then
-                rm -f "$file"
+                rm -f -- "$file"
             fi
         done
+        cp -- "$CONFIG_FILE" "$PRESETS_DIR/$name.json" || exit 1
+        wall_path=$(jq -r '.background.wallpaperPath // ""' "$CONFIG_FILE" 2>/dev/null)
+        if [[ -f "$wall_path" ]]; then
+            ext="${wall_path##*.}"
+            cp -- "$wall_path" "$PRESETS_DIR/$name.$ext"
+        fi
+        cache_snapshot "$name"
         ;;
+
+    load)
+        valid_name || exit 1
+        [[ -f "$PRESETS_DIR/$name.json" ]] || exit 1
+        register_request || exit 0
+        cancel_previous_generator
+        write_status "applying" ""
+
+        apply_result=$(python3 "$SCRIPTS_DIR/presets_helper.py" apply \
+            "$PRESETS_DIR/$name.json" "$CONFIG_FILE" "$PRESETS_DIR" "$name" \
+            "$TOKEN_FILE" "$request_id" 2>/tmp/presets_apply_error.log) || {
+                write_status "failed" "config"
+                exit 1
+            }
+
+        is_current_request || exit 0
+        if [[ "$apply_result" == *'"superseded": true'* || "$apply_result" == *'"superseded":true'* ]]; then
+            exit 0
+        fi
+
+        theming_enabled=$(jq -r '.appearance.wallpaperTheming.enableAppsAndShell // true' "$CONFIG_FILE" 2>/dev/null)
+        if [[ "$theming_enabled" != "true" ]]; then
+            write_status "success" "config-only"
+            exit 0
+        fi
+
+        if restore_cached_theme "$name"; then
+            write_status "success" "cached"
+            bash "$SCRIPTS_DIR/preset_post_apply.sh" "$request_id" "$TOKEN_FILE" >/dev/null 2>&1 &
+        else
+            # Legacy/raw imports get their config immediately. Color generation is
+            # isolated in a cancellable process group, never writes config, and
+            # fills the cache for the next switch.
+            start_cache_warmup "$name"
+            write_status "success" "warming-cache"
+        fi
+        ;;
+
+    delete)
+        valid_name || exit 1
+        rm -f -- "$PRESETS_DIR/$name.json"
+        for file in "$PRESETS_DIR/$name".*; do
+            if [[ -f "$file" && "${file##*.}" != "json" ]]; then
+                rm -f -- "$file"
+            fi
+        done
+        rm -rf -- "$(cache_dir_for "$name")"
+        ;;
+
     list)
         python3 "$SCRIPTS_DIR/presets_helper.py" list "$PRESETS_DIR"
         ;;
-    export)
-        if [[ -z "$name" ]]; then
-            fail_export "No preset name was provided."
-        fi
-        if [[ ! -f "$PRESETS_DIR/$name.json" ]]; then
-            fail_export "Preset not found: $name"
-        fi
 
-        if ! command -v zip >/dev/null 2>&1; then
-            fail_export "The 'zip' utility is not installed."
-        fi
-        
-        if command -v zenity >/dev/null; then
+    export)
+        valid_name || fail_export "Invalid preset name."
+        [[ -f "$PRESETS_DIR/$name.json" ]] || fail_export "Preset not found: $name"
+        command -v zip >/dev/null 2>&1 || fail_export "The 'zip' utility is not installed."
+
+        if command -v zenity >/dev/null 2>&1; then
             DEST_ZIP=$(zenity --file-selection --save --confirm-overwrite --filename="$HOME/${name}.zip" --file-filter="ZIP | *.zip" 2>/dev/null)
         else
             DEST_ZIP=$(kdialog --getsavefilename "$HOME/${name}.zip" "*.zip" 2>/dev/null)
         fi
-        
-        if [[ -n "$DEST_ZIP" ]]; then
-            # If the user selected .zip but extension wasn't appended automatically:
-            if [[ "$DEST_ZIP" != *.zip ]]; then
-                DEST_ZIP="${DEST_ZIP}.zip"
-            fi
 
+        if [[ -n "$DEST_ZIP" ]]; then
+            [[ "$DEST_ZIP" == *.zip ]] || DEST_ZIP="${DEST_ZIP}.zip"
             DEST_DIR=$(dirname -- "$DEST_ZIP")
-            if [[ ! -d "$DEST_DIR" ]]; then
-                fail_export "Destination directory does not exist: $DEST_DIR"
-            fi
-            if [[ ! -w "$DEST_DIR" ]]; then
-                fail_export "Destination directory is not writable: $DEST_DIR"
-            fi
-            
-            if ! TMP_DIR=$(mktemp -d /tmp/preset_export_XXXXXX); then
-                fail_export "Could not create a temporary export directory."
-            fi
-            
-            # Copy and sanitize JSON config
-            if ! cp "$PRESETS_DIR/$name.json" "$TMP_DIR/config.json"; then
-                rm -rf "$TMP_DIR"
-                fail_export "Could not copy the preset configuration."
-            fi
-            if ! python3 "$SCRIPTS_DIR/presets_helper.py" sanitize "$TMP_DIR/config.json" "$TMP_DIR/config.json"; then
-                rm -rf "$TMP_DIR"
-                fail_export "Could not sanitize the preset configuration."
-            fi
-            
-            # Find and copy wallpaper if it exists
-            # Look for MyPreset.* excluding .json and .zip
+            [[ -d "$DEST_DIR" ]] || fail_export "Destination directory does not exist: $DEST_DIR"
+            [[ -w "$DEST_DIR" ]] || fail_export "Destination directory is not writable: $DEST_DIR"
+
+            TMP_DIR=$(mktemp -d /tmp/preset_export_XXXXXX) || fail_export "Could not create a temporary export directory."
+            trap 'rm -rf -- "${TMP_DIR:-}"' EXIT
+
+            cp -- "$PRESETS_DIR/$name.json" "$TMP_DIR/config.json" || fail_export "Could not copy the preset configuration."
+            python3 "$SCRIPTS_DIR/presets_helper.py" sanitize "$TMP_DIR/config.json" "$TMP_DIR/config.json" \
+                || fail_export "Could not sanitize the preset configuration."
+
             for file in "$PRESETS_DIR/$name".*; do
                 if [[ -f "$file" ]]; then
                     ext="${file##*.}"
                     if [[ "$ext" != "json" && "$ext" != "zip" ]]; then
-                        if ! cp "$file" "$TMP_DIR/wallpaper.$ext"; then
-                            rm -rf "$TMP_DIR"
-                            fail_export "Could not copy the preset wallpaper."
-                        fi
+                        cp -- "$file" "$TMP_DIR/wallpaper.$ext" || fail_export "Could not copy the preset wallpaper."
                         break
                     fi
                 fi
             done
-            
-            # Zip everything
-            if ! (cd "$TMP_DIR" && zip -r "$DEST_ZIP" .); then
-                rm -rf "$TMP_DIR"
-                fail_export "Could not write the archive to: $DEST_ZIP"
+
+            cache_dir=$(cache_dir_for "$name")
+            if [[ -f "$cache_dir/colors.json" ]]; then
+                mkdir -p "$TMP_DIR/preset-cache"
+                cp -- "$cache_dir/colors.json" "$TMP_DIR/preset-cache/colors.json"
+                [[ ! -f "$cache_dir/material_colors.scss" ]] || cp -- "$cache_dir/material_colors.scss" "$TMP_DIR/preset-cache/material_colors.scss"
             fi
 
-            if [[ ! -s "$DEST_ZIP" ]]; then
-                rm -rf "$TMP_DIR"
-                fail_export "The archive was not created: $DEST_ZIP"
-            fi
-            
-            # Cleanup
-            rm -rf "$TMP_DIR"
+            (cd "$TMP_DIR" && zip -qr "$DEST_ZIP" .) || fail_export "Could not write the archive to: $DEST_ZIP"
+            [[ -s "$DEST_ZIP" ]] || fail_export "The archive was not created: $DEST_ZIP"
+
+            rm -rf -- "$TMP_DIR"
+            trap - EXIT
             printf '[presets.sh] Exported preset to: %s\n' "$DEST_ZIP"
             notify_export normal "Preset exported" "Saved to: $DEST_ZIP"
         else
@@ -163,33 +284,33 @@ case $action in
             notify_export low "Preset export cancelled" "No destination was selected."
         fi
         ;;
+
     import)
-        if command -v zenity >/dev/null; then
+        if command -v zenity >/dev/null 2>&1; then
             FILE=$(zenity --file-selection --file-filter="Presets (*.zip *.json) | *.zip *.json" 2>/dev/null)
         else
             FILE=$(kdialog --getopenfilename "$HOME" "*.zip *.json" 2>/dev/null)
         fi
-        
+
         if [[ -n "$FILE" && -f "$FILE" ]]; then
             preset_name=$(basename "$FILE" | sed 's/\.[^.]*$//')
+            name="$preset_name"
+            valid_name || exit 1
             ext="${FILE##*.}"
-            ext=$(echo "$ext" | tr '[:upper:]' '[:lower:]')
-            
+            ext=$(printf '%s' "$ext" | tr '[:upper:]' '[:lower:]')
+
             if [[ "$ext" == "json" ]]; then
-                # Clean/sanitize paths even on raw JSON import to be safe
-                mkdir -p "$PRESETS_DIR"
-                python3 "$SCRIPTS_DIR/presets_helper.py" sanitize "$FILE" "$PRESETS_DIR/$preset_name.json"
+                python3 "$SCRIPTS_DIR/presets_helper.py" sanitize "$FILE" "$PRESETS_DIR/$preset_name.json" || exit 1
                 echo 'success'
             elif [[ "$ext" == "zip" ]]; then
-                TMP_DIR=$(mktemp -d /tmp/preset_import_XXXXXX)
-                unzip -o "$FILE" -d "$TMP_DIR" >/dev/null
-                
-                # Check for config file
+                TMP_DIR=$(mktemp -d /tmp/preset_import_XXXXXX) || exit 1
+                trap 'rm -rf -- "${TMP_DIR:-}"' EXIT
+                unzip -oq "$FILE" -d "$TMP_DIR" || exit 1
+
                 config_json=""
                 if [[ -f "$TMP_DIR/config.json" ]]; then
                     config_json="$TMP_DIR/config.json"
                 else
-                    # Fallback to any json in zip
                     for f in "$TMP_DIR"/*.json; do
                         if [[ -f "$f" ]]; then
                             config_json="$f"
@@ -197,27 +318,38 @@ case $action in
                         fi
                     done
                 fi
-                
+
                 if [[ -n "$config_json" ]]; then
-                    mkdir -p "$PRESETS_DIR"
-                    # Sanitize paths when importing config
-                    python3 "$SCRIPTS_DIR/presets_helper.py" sanitize "$config_json" "$PRESETS_DIR/$preset_name.json"
-                    
-                    # Find wallpaper
+                    python3 "$SCRIPTS_DIR/presets_helper.py" sanitize "$config_json" "$PRESETS_DIR/$preset_name.json" || exit 1
+
                     for f in "$TMP_DIR"/*; do
                         if [[ -f "$f" ]]; then
                             f_ext="${f##*.}"
-                            f_ext=$(echo "$f_ext" | tr '[:upper:]' '[:lower:]')
+                            f_ext=$(printf '%s' "$f_ext" | tr '[:upper:]' '[:lower:]')
                             if [[ "$f_ext" != "json" && "$f_ext" != "zip" ]]; then
-                                cp "$f" "$PRESETS_DIR/$preset_name.$f_ext"
+                                cp -- "$f" "$PRESETS_DIR/$preset_name.$f_ext"
                                 break
                             fi
                         fi
                     done
+
+                    cache_dir=$(cache_dir_for "$preset_name")
+                    if [[ -f "$TMP_DIR/preset-cache/colors.json" ]]; then
+                        mkdir -p "$cache_dir"
+                        atomic_copy "$TMP_DIR/preset-cache/colors.json" "$cache_dir/colors.json" || true
+                        atomic_copy "$TMP_DIR/preset-cache/material_colors.scss" "$cache_dir/material_colors.scss" || true
+                        printf '%s\n' "$preset_name" > "$cache_dir/name"
+                    fi
                     echo 'success'
                 fi
-                rm -rf "$TMP_DIR"
+                rm -rf -- "$TMP_DIR"
+                trap - EXIT
             fi
         fi
+        ;;
+
+    *)
+        printf '[presets.sh] Unknown action: %s\n' "$action" >&2
+        exit 1
         ;;
 esac

--- a/dots/.config/quickshell/ii/scripts/presets.sh
+++ b/dots/.config/quickshell/ii/scripts/presets.sh
@@ -121,17 +121,29 @@ write_status() {
     mv -f -- "$tmp" "$STATUS_FILE"
 }
 
+generator_process_matches() {
+    local pid="$1"
+    [[ "$pid" =~ ^[0-9]+$ && -r "/proc/$pid/cmdline" ]] || return 1
+    tr '\0' '\n' < "/proc/$pid/cmdline" 2>/dev/null | grep -Fxq "$SCRIPTS_DIR/preset_generate_theme.sh"
+}
+
 cancel_previous_generator() {
     [[ -f "$GENERATOR_PID_FILE" ]] || return 0
     local old_request old_pid
     IFS=$'\t' read -r old_request old_pid < "$GENERATOR_PID_FILE" || true
-    if [[ "$old_pid" =~ ^[0-9]+$ && "$old_request" != "$request_id" ]]; then
+
+    # PID files outlive processes if a generator is superseded before its EXIT
+    # trap can clean up. Verify the PID still belongs to our exact warmup script
+    # before ever signalling its process group; this makes PID reuse harmless.
+    if [[ "$old_request" != "$request_id" ]] && generator_process_matches "$old_pid"; then
         kill -- "-$old_pid" >/dev/null 2>&1 || true
         for _ in {1..10}; do
-            kill -0 "$old_pid" >/dev/null 2>&1 || break
+            generator_process_matches "$old_pid" || break
             sleep 0.01
         done
-        kill -KILL -- "-$old_pid" >/dev/null 2>&1 || true
+        if generator_process_matches "$old_pid"; then
+            kill -KILL -- "-$old_pid" >/dev/null 2>&1 || true
+        fi
     fi
     rm -f -- "$GENERATOR_PID_FILE"
 }
@@ -147,6 +159,12 @@ start_cache_warmup() {
     local generator_pid=$!
     printf '%s\t%s\n' "$request_id" "$generator_pid" > "${GENERATOR_PID_FILE}.tmp.$$"
     mv -f -- "${GENERATOR_PID_FILE}.tmp.$$" "$GENERATOR_PID_FILE"
+
+    # If it exited in the tiny spawn→pidfile race, do not leave a stale PID for
+    # the next switch. A running generator removes its own matching entry.
+    if ! generator_process_matches "$generator_pid"; then
+        rm -f -- "$GENERATOR_PID_FILE"
+    fi
 }
 
 case "$action" in

--- a/dots/.config/quickshell/ii/scripts/presets.sh
+++ b/dots/.config/quickshell/ii/scripts/presets.sh
@@ -63,13 +63,24 @@ cache_snapshot() {
     atomic_copy "$GENERATED_DIR/colors.json" "$cache_dir/colors.json" || true
     atomic_copy "$GENERATED_DIR/material_colors.scss" "$cache_dir/material_colors.scss" || true
     printf '%s\n' "$preset_name" > "$cache_dir/name"
+    if [[ -f "$PRESETS_DIR/$preset_name.json" ]]; then
+        sha256sum -- "$PRESETS_DIR/$preset_name.json" | cut -d' ' -f1 > "$cache_dir/config.sha256"
+    fi
 }
 
 restore_cached_theme() {
     local preset_name="$1"
     local cache_dir
     cache_dir=$(cache_dir_for "$preset_name")
-    [[ -f "$cache_dir/colors.json" ]] || return 1
+    [[ -f "$cache_dir/colors.json" && -f "$cache_dir/config.sha256" ]] || return 1
+
+    # Never trust a palette cache after the preset JSON was edited by hand or
+    # rewritten by another tool. A mismatch falls back to asynchronous warmup
+    # and refreshes the cache without penalizing the config switch itself.
+    local expected_hash current_hash
+    expected_hash=$(cat -- "$cache_dir/config.sha256" 2>/dev/null)
+    current_hash=$(sha256sum -- "$PRESETS_DIR/$preset_name.json" 2>/dev/null | cut -d' ' -f1)
+    [[ -n "$expected_hash" && "$expected_hash" == "$current_hash" ]] || return 1
 
     # Presets do not own the global light/dark mode. Reusing an exported cache
     # from the opposite mode would emit darkmodeChanged and can recursively
@@ -288,6 +299,9 @@ case "$action" in
                 mkdir -p "$TMP_DIR/preset-cache"
                 cp -- "$cache_dir/colors.json" "$TMP_DIR/preset-cache/colors.json"
                 [[ ! -f "$cache_dir/material_colors.scss" ]] || cp -- "$cache_dir/material_colors.scss" "$TMP_DIR/preset-cache/material_colors.scss"
+                # config.json was sanitized for portability, so fingerprint the
+                # exported representation rather than copying the local hash.
+                sha256sum -- "$TMP_DIR/config.json" | cut -d' ' -f1 > "$TMP_DIR/preset-cache/config.sha256"
             fi
 
             (cd "$TMP_DIR" && zip -qr "$DEST_ZIP" .) || fail_export "Could not write the archive to: $DEST_ZIP"
@@ -356,6 +370,7 @@ case "$action" in
                         mkdir -p "$cache_dir"
                         atomic_copy "$TMP_DIR/preset-cache/colors.json" "$cache_dir/colors.json" || true
                         atomic_copy "$TMP_DIR/preset-cache/material_colors.scss" "$cache_dir/material_colors.scss" || true
+                        atomic_copy "$TMP_DIR/preset-cache/config.sha256" "$cache_dir/config.sha256" || true
                         printf '%s\n' "$preset_name" > "$cache_dir/name"
                     fi
                     echo 'success'

--- a/dots/.config/quickshell/ii/scripts/presets_helper.py
+++ b/dots/.config/quickshell/ii/scripts/presets_helper.py
@@ -8,6 +8,8 @@ import sys
 import tempfile
 from contextlib import contextmanager
 
+VIDEO_EXTENSIONS = (".mp4", ".mkv", ".webm", ".avi", ".mov", ".m4v", ".ogv")
+
 
 def sanitize_val(val, home_dir):
     if isinstance(val, dict):
@@ -110,6 +112,50 @@ def deep_merge(base, overlay):
     return result
 
 
+def normalize_video_constraints(data):
+    """Make video/WPE presets valid before their single config commit.
+
+    Wallpapers.qml enforces these same invariants reactively. Doing it here
+    prevents a preset load from first committing an invalid combination and
+    then forcing a second Config.saveOptionsNow() write immediately after the
+    reload.
+    """
+    background = data.get("background")
+    if not isinstance(background, dict):
+        return data
+
+    wallpaper_path = str(background.get("wallpaperPath", "") or "").lower()
+    video_active = background.get("useWallpaperEngine") is True or wallpaper_path.endswith(VIDEO_EXTENSIONS)
+    if not video_active:
+        return data
+
+    background.update({
+        "blurWhenWindowsOpen": False,
+        "zoomOutEnabled": False,
+        "zoomOutStyle": 1,
+        "windowZoomOnOverview": False,
+        "windowZoomLiveCapture": False,
+        "cheatsheetZoomOut": False,
+        "overviewZoomOut": False,
+        "workspaceBlur": False,
+    })
+
+    parallax = background.get("parallax")
+    if isinstance(parallax, dict):
+        parallax.update({
+            "vertical": False,
+            "autoVertical": False,
+            "enableWorkspace": False,
+            "enableSidebar": False,
+            "loop": False,
+            "invertHorizontal": False,
+            "invertVertical": False,
+            "workspaceZoom": 1.0,
+        })
+
+    return data
+
+
 def find_wallpaper_fallback(presets_dir, preset_name):
     pattern = os.path.join(presets_dir, f"{glob.escape(preset_name)}.*")
     for filepath in glob.glob(pattern):
@@ -131,8 +177,7 @@ def validate_preset_name(name):
 def load_json(path, fallback=None):
     try:
         with open(path, "r", encoding="utf-8") as handle:
-            value = json.load(handle)
-        return value
+            return json.load(handle)
     except FileNotFoundError:
         return fallback
 
@@ -223,7 +268,7 @@ def apply_preset(input_path, output_path, presets_dir, preset_name, token_file, 
 
     # Preserve options added by newer shell versions when applying an older
     # preset, matching the behavior of the upstream end4 preset path.
-    merged = deep_merge(current, preset)
+    merged = normalize_video_constraints(deep_merge(current, preset))
 
     # The token check and atomic replace share the same lock used by the shell
     # when registering newer requests. Therefore an older request can either

--- a/dots/.config/quickshell/ii/scripts/presets_helper.py
+++ b/dots/.config/quickshell/ii/scripts/presets_helper.py
@@ -1,19 +1,23 @@
 #!/usr/bin/env python3
+import fcntl
+import glob
 import json
 import os
+import stat
 import sys
-import glob
+import tempfile
+from contextlib import contextmanager
+
 
 def sanitize_val(val, home_dir):
     if isinstance(val, dict):
         return {k: sanitize_val(v, home_dir) for k, v in val.items()}
-    elif isinstance(val, list):
+    if isinstance(val, list):
         return [sanitize_val(x, home_dir) for x in val]
-    elif isinstance(val, str):
-        if home_dir and home_dir in val:
-            return val.replace(home_dir, '$HOME')
-        return val
+    if isinstance(val, str) and home_dir and home_dir in val:
+        return val.replace(home_dir, "$HOME")
     return val
+
 
 def normalize_path_field(data, section_name, field_name, home_dir, fallback=None):
     section = data.get(section_name)
@@ -25,171 +29,275 @@ def normalize_path_field(data, section_name, field_name, home_dir, fallback=None
         return
 
     path = value.strip()
-    if path.startswith('file://'):
+    if path.startswith("file://"):
         path = path[7:]
 
-    if path == '$HOME' or path.startswith('$HOME' + os.sep):
+    if path == "$HOME" or path.startswith("$HOME" + os.sep):
         section[field_name] = path
         return
 
     if home_dir and (path == home_dir or path.startswith(home_dir + os.sep)):
-        section[field_name] = '$HOME' + path[len(home_dir):]
+        section[field_name] = "$HOME" + path[len(home_dir):]
     elif os.path.isabs(path) and fallback:
         section[field_name] = fallback
     else:
         section[field_name] = path
 
+
 def reset_monitor_bindings(data):
-    background = data.get('background')
-    if isinstance(background, dict) and isinstance(background.get('widgets'), dict):
-        widgets = background['widgets']
-        widgets['showOnlyOnSingleMonitor'] = False
-        widgets['targetMonitor'] = ''
+    background = data.get("background")
+    if isinstance(background, dict) and isinstance(background.get("widgets"), dict):
+        widgets = background["widgets"]
+        widgets["showOnlyOnSingleMonitor"] = False
+        widgets["targetMonitor"] = ""
 
-    bar = data.get('bar')
+    bar = data.get("bar")
     if isinstance(bar, dict):
-        bar['onlyShowOnSingleMonitor'] = False
-        bar['singleMonitorName'] = ''
-        bar['screenList'] = []
+        bar["onlyShowOnSingleMonitor"] = False
+        bar["singleMonitorName"] = ""
+        bar["screenList"] = []
 
-        floating_notch = bar.get('floatingNotch')
+        floating_notch = bar.get("floatingNotch")
         if isinstance(floating_notch, dict):
-            floating_notch['onlyShowOnSingleMonitor'] = False
-            floating_notch['singleMonitorName'] = ''
+            floating_notch["onlyShowOnSingleMonitor"] = False
+            floating_notch["singleMonitorName"] = ""
 
-    interactions = data.get('interactions')
-    if isinstance(interactions, dict) and isinstance(interactions.get('touchGestures'), dict):
-        interactions['touchGestures']['targetMonitor'] = 'auto'
+    interactions = data.get("interactions")
+    if isinstance(interactions, dict) and isinstance(interactions.get("touchGestures"), dict):
+        interactions["touchGestures"]["targetMonitor"] = "auto"
 
-    notifications = data.get('notifications')
-    if isinstance(notifications, dict) and isinstance(notifications.get('monitor'), dict):
-        notifications['monitor']['enable'] = False
-        notifications['monitor']['name'] = ''
+    notifications = data.get("notifications")
+    if isinstance(notifications, dict) and isinstance(notifications.get("monitor"), dict):
+        notifications["monitor"]["enable"] = False
+        notifications["monitor"]["name"] = ""
+
 
 def sanitize_data(data, home_dir):
-    if 'appearance' in data and isinstance(data['appearance'], dict):
-        icons = data['appearance'].get('icons')
+    if "appearance" in data and isinstance(data["appearance"], dict):
+        icons = data["appearance"].get("icons")
         if isinstance(icons, dict):
-            icons['enableThemed'] = False
-        data['appearance']['iconTheme'] = ''
+            icons["enableThemed"] = False
+        data["appearance"]["iconTheme"] = ""
 
     data = sanitize_val(data, home_dir)
-
-    # Keep user paths portable when a preset is imported by another account.
-    normalize_path_field(data, 'screenRecord', 'savePath', home_dir, '$HOME/Videos')
-    normalize_path_field(data, 'screenSnip', 'savePath', home_dir, '$HOME/Pictures/Screenshots')
-
-    # Monitor connector names are local to the source machine.
+    normalize_path_field(data, "screenRecord", "savePath", home_dir, "$HOME/Videos")
+    normalize_path_field(data, "screenSnip", "savePath", home_dir, "$HOME/Pictures/Screenshots")
     reset_monitor_bindings(data)
     return data
 
-def sanitize(input_path, output_path):
-    with open(input_path, 'r', encoding='utf-8') as f:
-        data = json.load(f)
-
-    home_dir = os.environ.get('HOME', '')
-    if home_dir.endswith('/'):
-        home_dir = home_dir[:-1]
-
-    data = sanitize_data(data, home_dir)
-
-    with open(output_path, 'w', encoding='utf-8') as f:
-        json.dump(data, f, indent=4)
 
 def expand_val(val, home_dir):
     if isinstance(val, dict):
         return {k: expand_val(v, home_dir) for k, v in val.items()}
-    elif isinstance(val, list):
+    if isinstance(val, list):
         return [expand_val(x, home_dir) for x in val]
-    elif isinstance(val, str):
-        if '$HOME' in val:
-            return val.replace('$HOME', home_dir)
-        return val
+    if isinstance(val, str) and "$HOME" in val:
+        return val.replace("$HOME", home_dir)
     return val
 
-def expand(input_path, output_path, presets_dir, preset_name):
-    with open(input_path, 'r', encoding='utf-8') as f:
-        data = json.load(f)
-        
-    home_dir = os.environ.get('HOME', '')
-    if home_dir.endswith('/'):
-        home_dir = home_dir[:-1]
-        
-    data = expand_val(data, home_dir)
-    
-    # Check if background.wallpaperPath exists
-    bg = data.get('background', {})
-    if isinstance(bg, dict):
-        wall_path = bg.get('wallpaperPath', '')
-        if not wall_path or not os.path.exists(wall_path):
-            # Check for fallback file in presets_dir
-            fallback = find_wallpaper_fallback(presets_dir, preset_name)
-            if fallback:
-                bg['wallpaperPath'] = fallback
-                data['background'] = bg
-                
-    with open(output_path, 'w', encoding='utf-8') as f:
-        json.dump(data, f, indent=4)
+
+def deep_merge(base, overlay):
+    """Merge mappings recursively; preset scalars/lists replace current values."""
+    if not isinstance(base, dict) or not isinstance(overlay, dict):
+        return overlay
+
+    result = dict(base)
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
 
 def find_wallpaper_fallback(presets_dir, preset_name):
-    pattern = os.path.join(presets_dir, f"{preset_name}.*")
+    pattern = os.path.join(presets_dir, f"{glob.escape(preset_name)}.*")
     for filepath in glob.glob(pattern):
         ext = os.path.splitext(filepath)[1].lower()
-        if ext not in ('.json', '.zip'):
+        if ext not in (".json", ".zip"):
             return filepath
     return None
 
-def list_presets(presets_dir):
-    home_dir = os.environ.get('HOME', '')
-    if home_dir.endswith('/'):
-        home_dir = home_dir[:-1]
-        
-    pattern = os.path.join(presets_dir, "*.json")
-    # Sort presets by name case-insensitively
-    preset_files = sorted(glob.glob(pattern), key=lambda x: os.path.basename(x).lower())
-    for json_path in preset_files:
-        filename = os.path.basename(json_path)
-        preset_name = os.path.splitext(filename)[0]
-        
+
+def validate_preset_name(name):
+    if not name or name in (".", ".."):
+        raise ValueError("preset name is empty or reserved")
+    if os.sep in name or (os.altsep and os.altsep in name):
+        raise ValueError("preset name may not contain path separators")
+    if any(ch in name for ch in ("\n", "\r", "\t", "\0")):
+        raise ValueError("preset name may not contain control characters")
+
+
+def load_json(path, fallback=None):
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        return value
+    except FileNotFoundError:
+        return fallback
+
+
+def atomic_json_write(path, data):
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
+
+    old_mode = None
+    try:
+        old_mode = stat.S_IMODE(os.stat(path).st_mode)
+    except FileNotFoundError:
+        pass
+
+    fd, tmp_path = tempfile.mkstemp(prefix=".preset-config-", suffix=".json", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=4)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if old_mode is not None:
+            os.chmod(tmp_path, old_mode)
+        os.replace(tmp_path, path)
+    finally:
         try:
-            with open(json_path, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-        except Exception:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+
+
+def sanitize(input_path, output_path):
+    data = load_json(input_path)
+    if not isinstance(data, dict):
+        raise ValueError("preset config must be a JSON object")
+
+    home_dir = os.environ.get("HOME", "").rstrip("/")
+    atomic_json_write(output_path, sanitize_data(data, home_dir))
+
+
+def prepare_preset(input_path, presets_dir, preset_name):
+    validate_preset_name(preset_name)
+    data = load_json(input_path)
+    if not isinstance(data, dict):
+        raise ValueError("preset config must be a JSON object")
+
+    home_dir = os.environ.get("HOME", "").rstrip("/")
+    data = expand_val(data, home_dir)
+    data.pop("_presetMeta", None)
+
+    background = data.get("background")
+    if isinstance(background, dict):
+        wall_path = background.get("wallpaperPath", "")
+        if not wall_path or not os.path.exists(wall_path):
+            fallback = find_wallpaper_fallback(presets_dir, preset_name)
+            if fallback:
+                background["wallpaperPath"] = fallback
+    return data
+
+
+def expand(input_path, output_path, presets_dir, preset_name):
+    atomic_json_write(output_path, prepare_preset(input_path, presets_dir, preset_name))
+
+
+@contextmanager
+def request_lock(token_file):
+    lock_path = token_file + ".lock"
+    os.makedirs(os.path.dirname(os.path.abspath(lock_path)), exist_ok=True)
+    with open(lock_path, "a+", encoding="utf-8") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        yield
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
+
+def request_is_current(token_file, request_id):
+    try:
+        with open(token_file, "r", encoding="utf-8") as handle:
+            return handle.read().strip() == request_id
+    except FileNotFoundError:
+        return False
+
+
+def apply_preset(input_path, output_path, presets_dir, preset_name, token_file, request_id):
+    preset = prepare_preset(input_path, presets_dir, preset_name)
+    current = load_json(output_path, fallback={})
+    if not isinstance(current, dict):
+        current = {}
+
+    # Preserve options added by newer shell versions when applying an older
+    # preset, matching the behavior of the upstream end4 preset path.
+    merged = deep_merge(current, preset)
+
+    # The token check and atomic replace share the same lock used by the shell
+    # when registering newer requests. Therefore an older request can either
+    # commit before a newer click is registered or be skipped entirely; it can
+    # never overwrite a newer request after that newer request registered.
+    with request_lock(token_file):
+        if not request_is_current(token_file, request_id):
+            print(json.dumps({"applied": False, "superseded": True}))
+            return
+        atomic_json_write(output_path, merged)
+
+    appearance = merged.get("appearance", {}) if isinstance(merged.get("appearance"), dict) else {}
+    background = merged.get("background", {}) if isinstance(merged.get("background"), dict) else {}
+    theming = appearance.get("wallpaperTheming", {}) if isinstance(appearance.get("wallpaperTheming"), dict) else {}
+
+    print(json.dumps({
+        "applied": True,
+        "superseded": False,
+        "colorEngine": appearance.get("colorEngine", "vynx"),
+        "wallpaperPath": background.get("wallpaperPath", ""),
+        "themingEnabled": theming.get("enableAppsAndShell", True) is not False,
+    }))
+
+
+def list_presets(presets_dir):
+    home_dir = os.environ.get("HOME", "").rstrip("/")
+    pattern = os.path.join(presets_dir, "*.json")
+    preset_files = sorted(glob.glob(pattern), key=lambda path: os.path.basename(path).lower())
+
+    for json_path in preset_files:
+        preset_name = os.path.splitext(os.path.basename(json_path))[0]
+        try:
+            data = load_json(json_path)
+        except (OSError, ValueError, json.JSONDecodeError):
             continue
-            
-        bg = data.get('background', {})
-        wall_path = ''
-        if isinstance(bg, dict):
-            wall_path = bg.get('wallpaperPath', '')
-            if wall_path:
-                wall_path = wall_path.replace('$HOME', home_dir)
-                
+        if not isinstance(data, dict):
+            continue
+
+        background = data.get("background", {})
+        wall_path = background.get("wallpaperPath", "") if isinstance(background, dict) else ""
+        if wall_path:
+            wall_path = wall_path.replace("$HOME", home_dir)
         if not wall_path or not os.path.exists(wall_path):
             fallback = find_wallpaper_fallback(presets_dir, preset_name)
             if fallback:
                 wall_path = fallback
-                
-        print(json.dumps({"name": preset_name, "wallpaper": wall_path}))
+
+        print(json.dumps({"name": preset_name, "wallpaper": wall_path}, separators=(",", ":")))
+
 
 def main():
     if len(sys.argv) < 2:
         sys.exit(1)
-        
+
     action = sys.argv[1]
-    if action == 'sanitize':
+    if action == "sanitize":
         if len(sys.argv) < 4:
             sys.exit(1)
         sanitize(sys.argv[2], sys.argv[3])
-    elif action == 'expand':
+    elif action == "expand":
         if len(sys.argv) < 6:
             sys.exit(1)
         expand(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
-    elif action == 'list':
+    elif action == "apply":
+        if len(sys.argv) < 8:
+            sys.exit(1)
+        apply_preset(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6], sys.argv[7])
+    elif action == "list":
         if len(sys.argv) < 3:
             sys.exit(1)
         list_presets(sys.argv[2])
     else:
         sys.exit(1)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/dots/.config/quickshell/ii/services/HyprlandSettings.qml
+++ b/dots/.config/quickshell/ii/services/HyprlandSettings.qml
@@ -8,6 +8,8 @@ import qs
 Singleton {
     id: root
 
+    property string lastAppLaunchAnimationSignature: ""
+
     function changeKey(key, value) {
         if (/['"\\`$|&;]/.test(String(value)) || /['"\\`$|&;]/.test(String(key))) {
             console.error("[HyprlandSettings] Unsafe characters rejected:", key, value)
@@ -57,11 +59,19 @@ Singleton {
         Quickshell.execDetached(["hyprctl", "eval", luaExpr]);
     }
 
-    function updateAppLaunchAnimation(enabled, startPercent, speed, curve) {
+    function updateAppLaunchAnimation(enabled, startPercent, speed, curve, force = false) {
         const isEnabled = enabled !== false;
         const percent = Math.max(5, Math.min(100, Math.round(Number(startPercent) || 20)));
         const animSpeed = Math.max(0.5, Math.min(20, Number(speed) || 3.2));
         const animCurve = (typeof curve === "string" && curve.trim() !== "") ? curve.trim() : "iiAppOpen";
+        const signature = [isEnabled ? "1" : "0", percent, animSpeed.toFixed(2), animCurve].join("|");
+
+        // Config.onLoaded calls this after every config reload. Avoid spawning
+        // four hyprctl processes when a preset did not actually change the app
+        // launch animation.
+        if (!force && signature === root.lastAppLaunchAnimationSignature)
+            return;
+        root.lastAppLaunchAnimationSignature = signature;
 
         const inStyle = isEnabled ? ("popin " + percent + "%") : "popin 100%";
         const outPercent = Math.min(90, Math.round(percent + (100 - percent) * 0.5));
@@ -78,7 +88,6 @@ Singleton {
 
     function setLayout(layout) {
         if (layout !== "default" && layout !== "scrolling" && layout !== "dwindle" && layout !== "monocle" && layout !== "master") return
-        // console.log("[HyprlandSettings] Setting layout to", layout)
         changeKey("general:layout", layout)
         Persistent.states.hyprland.layout = layout
     }

--- a/dots/.config/quickshell/ii/services/HyprlandSettings.qml
+++ b/dots/.config/quickshell/ii/services/HyprlandSettings.qml
@@ -88,6 +88,7 @@ Singleton {
 
     function setLayout(layout) {
         if (layout !== "default" && layout !== "scrolling" && layout !== "dwindle" && layout !== "monocle" && layout !== "master") return
+        // console.log("[HyprlandSettings] Setting layout to", layout)
         changeKey("general:layout", layout)
         Persistent.states.hyprland.layout = layout
     }

--- a/dots/.config/quickshell/ii/services/MaterialThemeLoader.qml
+++ b/dots/.config/quickshell/ii/services/MaterialThemeLoader.qml
@@ -9,59 +9,82 @@ import Quickshell.Hyprland
 
 /**
  * Automatically reloads generated material colors.
- * It is necessary to run reapplyTheme() on startup because Singletons are lazily loaded.
+ *
+ * File notifications can arrive more than once for one atomic replace. Keep a
+ * single scheduled apply and fingerprint the payload so a preset switch cannot
+ * fan out into two complete Appearance.m3colors invalidation waves.
  */
 Singleton {
     id: root
     property string filePath: Directories.generatedMaterialThemePath
+    property string lastAppliedContent: ""
+    property int retryCount: 0
 
     function reapplyTheme() {
+        root.lastAppliedContent = "";
         themeFileView.reload();
+    }
+
+    function normalizedColor(value) {
+        return String(value ?? "").trim().toLowerCase();
     }
 
     function applyColors(fileContent) {
         try {
-            if (!fileContent || fileContent.trim() === "") {
-                console.log("[MaterialThemeLoader] applyColors: empty content, skipping")
+            const content = String(fileContent || "").trim();
+            if (!content) {
+                console.log("[MaterialThemeLoader] applyColors: empty content, skipping");
                 return;
             }
+            if (content === root.lastAppliedContent)
+                return;
 
-            const json = JSON.parse(fileContent)
-            const skip = { "darkmode": true, "transparent": true }
+            const json = JSON.parse(content);
+            const skip = { "darkmode": true, "transparent": true };
+            let changed = 0;
+
             for (const key in json) {
-                if (json.hasOwnProperty(key) && !skip[key]) {
-                    Appearance.m3colors[root._toM3Key(key)] = json[key]
-                }
+                if (!json.hasOwnProperty(key) || skip[key])
+                    continue;
+
+                const propertyName = root._toM3Key(key);
+                const nextValue = json[key];
+                if (root.normalizedColor(Appearance.m3colors[propertyName]) === root.normalizedColor(nextValue))
+                    continue;
+
+                Appearance.m3colors[propertyName] = nextValue;
+                changed++;
             }
 
-            root.updateDarkMode(json)
-            console.log("[MaterialThemeLoader] applyColors: darkmode=", Appearance.m3colors.darkmode, "bg=", Appearance.m3colors.m3background)
+            root.updateDarkMode(json);
+            root.lastAppliedContent = content;
+            console.log("[MaterialThemeLoader] applied", changed, "changed colors; darkmode=", Appearance.m3colors.darkmode);
         } catch (e) {
-            console.log("[MaterialThemeLoader] Error parsing colors.json:", e)
+            console.log("[MaterialThemeLoader] Error parsing colors.json:", e);
         }
     }
 
     function updateDarkMode(json) {
+        let nextDarkMode = null;
         if (typeof json.darkmode === "boolean") {
-            Appearance.m3colors.darkmode = json.darkmode;
-            return;
+            nextDarkMode = json.darkmode;
+        } else {
+            const background = json.background ?? json.surface;
+            if (background !== undefined && background !== null && background !== "")
+                nextDarkMode = Qt.color(background).hslLightness < 0.5;
         }
 
-        const background = json.background ?? json.surface;
-        if (background !== undefined && background !== null && background !== "") {
-            Appearance.m3colors.darkmode = Qt.color(background).hslLightness < 0.5;
-        }
+        if (nextDarkMode !== null && Appearance.m3colors.darkmode !== nextDarkMode)
+            Appearance.m3colors.darkmode = nextDarkMode;
     }
 
     function _toM3Key(key) {
-        const camelCaseKey = key.replace(/_([a-z])/g, (g) => g[1].toUpperCase())
-        return `m3${camelCaseKey}`
+        const camelCaseKey = key.replace(/_([a-z])/g, (g) => g[1].toUpperCase());
+        return `m3${camelCaseKey}`;
     }
 
-    property int retryCount: 0
-
     function resetFilePathNextTime() {
-        resetFilePathNextWallpaperChange.enabled = true
+        resetFilePathNextWallpaperChange.enabled = true;
     }
 
     Connections {
@@ -69,9 +92,9 @@ Singleton {
         enabled: false
         target: Config.options.background
         function onWallpaperPathChanged() {
-            root.filePath = ""
-            root.filePath = Directories.generatedMaterialThemePath
-            resetFilePathNextWallpaperChange.enabled = false
+            root.filePath = "";
+            root.filePath = Directories.generatedMaterialThemePath;
+            resetFilePathNextWallpaperChange.enabled = false;
         }
     }
 
@@ -82,49 +105,42 @@ Singleton {
         running: false
         onTriggered: {
             if (root.retryCount < 5) {
-                root.retryCount++
-                console.log("[MaterialThemeLoader] Retrying file reload, attempt:", root.retryCount)
-                themeFileView.reload()
+                root.retryCount++;
+                themeFileView.reload();
             } else {
-                console.log("[MaterialThemeLoader] Max retries reached, resetting path to re-establish watch")
-                root.filePath = ""
-                root.filePath = Directories.generatedMaterialThemePath
-                root.retryCount = 0
+                console.log("[MaterialThemeLoader] Max retries reached, resetting file watch");
+                root.filePath = "";
+                root.filePath = Directories.generatedMaterialThemePath;
+                root.retryCount = 0;
             }
         }
     }
 
+    // Coalesce FileView's file-changed/load signals into exactly one apply on
+    // the next event-loop turn. Atomic preset cache copies no longer need the
+    // old second delayed read.
     Timer {
-        id: delayedFileRead
-        interval: Config.options?.hacks?.arbitraryRaceConditionDelay ?? 100
+        id: applyTimer
+        interval: 0
         repeat: false
         running: false
-        onTriggered: {
-            root.applyColors(themeFileView.text())
-        }
+        onTriggered: root.applyColors(themeFileView.text())
     }
 
     FileView {
         id: themeFileView
         path: Qt.resolvedUrl(root.filePath)
         watchChanges: true
-        onFileChanged: {
-            console.log("[MaterialThemeLoader] onFileChanged triggered, reloading...")
-            this.reload();
-            delayedFileRead.restart();
+
+        onFileChanged: themeFileView.reload()
+
+        onLoaded: {
+            root.retryCount = 0;
+            retryTimer.stop();
+            applyTimer.restart();
         }
-        onLoadedChanged: {
-            console.log("[MaterialThemeLoader] onLoadedChanged, loaded=", themeFileView.loaded)
-            if (themeFileView.loaded) {
-                root.retryCount = 0
-                retryTimer.stop()
-                root.applyColors(themeFileView.text())
-            }
-        }
-        onLoadFailed: {
-            console.log("[MaterialThemeLoader] onLoadFailed, starting retry timer")
-            retryTimer.start()
-        }
+
+        onLoadFailed: retryTimer.start()
     }
 
     function toggleLightDark() {
@@ -150,10 +166,7 @@ Singleton {
     GlobalShortcut {
         name: "toggleLightDark"
         description: "Toggles between dark theme and light theme"
-
-        onPressed: {
-            root.toggleLightDark();
-        }
+        onPressed: root.toggleLightDark()
     }
 
     IpcHandler {

--- a/dots/.config/quickshell/ii/services/PresetManager.qml
+++ b/dots/.config/quickshell/ii/services/PresetManager.qml
@@ -1,0 +1,119 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs
+import qs.modules.common
+import qs.modules.common.functions
+
+Singleton {
+    id: root
+
+    property bool applying: false
+    property string activePreset: ""
+    property string activeRequest: ""
+    property string lastMode: ""
+    property real generation: Date.now()
+
+    readonly property string statusPath: FileUtils.trimFileProtocol(`${Directories.state}/user/preset_apply_status`)
+
+    signal applied(string name, bool success, string mode)
+
+    function nextRequestId() {
+        const now = Date.now();
+        root.generation = Math.max(root.generation + 1, now);
+        return Math.floor(root.generation).toString();
+    }
+
+    function apply(name) {
+        const cleanName = String(name || "").trim();
+        if (cleanName.length === 0)
+            return;
+
+        // Hide Settings before touching config. shell.qml listens to applying and
+        // destroys the warm Settings tree immediately so it cannot participate in
+        // the config/theme invalidation wave.
+        GlobalStates.settingsOpen = false;
+        root.activePreset = cleanName;
+        root.activeRequest = root.nextRequestId();
+        root.lastMode = "";
+        root.applying = true;
+        applyTimeout.restart();
+
+        Quickshell.execDetached([
+            Directories.scriptPath + "/presets.sh",
+            "load",
+            cleanName,
+            root.activeRequest
+        ]);
+    }
+
+    function consumeStatus() {
+        if (!statusFile.loaded)
+            return;
+
+        const text = statusFile.text().trim();
+        if (!text)
+            return;
+
+        const fields = text.split("\t");
+        if (fields.length < 2 || fields[0] !== root.activeRequest)
+            return;
+
+        const state = fields[1];
+        if (state !== "success" && state !== "failed")
+            return;
+
+        const mode = fields.length >= 3 ? fields[2] : "";
+        applyTimeout.stop();
+        root.lastMode = mode;
+        root.applying = false;
+        root.applied(root.activePreset, state === "success", mode);
+    }
+
+    Timer {
+        id: statusReadTimer
+        interval: 16
+        repeat: false
+        onTriggered: root.consumeStatus()
+    }
+
+    Timer {
+        id: statusPollTimer
+        interval: 50
+        repeat: true
+        running: root.applying
+        onTriggered: statusFile.reload()
+    }
+
+    Timer {
+        id: applyTimeout
+        // A safety valve only. Normal cached applies finish in a few filesystem
+        // operations; uncached legacy imports may need Matugen on first use.
+        interval: 20000
+        repeat: false
+        onTriggered: {
+            if (!root.applying)
+                return;
+            console.warn("[PresetManager] Timed out waiting for preset apply status:", root.activePreset);
+            root.applying = false;
+            root.applied(root.activePreset, false, "timeout");
+        }
+    }
+
+    FileView {
+        id: statusFile
+        path: root.statusPath
+        watchChanges: true
+        printErrors: false
+
+        onFileChanged: {
+            statusFile.reload();
+            statusReadTimer.restart();
+        }
+
+        onLoaded: statusReadTimer.restart()
+    }
+}

--- a/dots/.config/quickshell/ii/services/Wallpapers.qml
+++ b/dots/.config/quickshell/ii/services/Wallpapers.qml
@@ -225,6 +225,28 @@ Singleton {
         if (!parallax)
             return;
 
+        // Most preset loads now arrive already normalized by presets_helper.py.
+        // Avoid mutating the adapter and forcing a second config write when the
+        // constraints are already satisfied.
+        const alreadyConstrained = background.blurWhenWindowsOpen === false
+            && background.zoomOutEnabled === false
+            && background.zoomOutStyle === 1
+            && background.windowZoomOnOverview === false
+            && background.windowZoomLiveCapture === false
+            && background.cheatsheetZoomOut === false
+            && background.overviewZoomOut === false
+            && background.workspaceBlur === false
+            && parallax.vertical === false
+            && parallax.autoVertical === false
+            && parallax.enableWorkspace === false
+            && parallax.enableSidebar === false
+            && parallax.loop === false
+            && parallax.invertHorizontal === false
+            && parallax.invertVertical === false
+            && parallax.workspaceZoom === 1.0;
+        if (alreadyConstrained)
+            return;
+
         root.enforcingVideoWallpaperConstraints = true;
 
         background.blurWhenWindowsOpen = false;

--- a/dots/.config/quickshell/ii/shell.qml
+++ b/dots/.config/quickshell/ii/shell.qml
@@ -21,7 +21,6 @@ ShellRoot {
     property string openRgbApplyScript: Quickshell.shellPath("scripts/colors/openRGB/apply_openrgb.py")
     property bool openRgbStartupApplied: false
 
-    // Stuff for every panel family
     ReloadPopup {}
 
     Component.onCompleted: {
@@ -39,13 +38,13 @@ ShellRoot {
         Updates.load();
         DarkModeService.automatic;
         ChangelogService.load();
-        SoundService.indexReady; // Instantiate: scans sound themes, plays login sound if enabled
-        VideoColorSampler.active; // Touch singleton to initialize
-        WaterReminderService.enabled; // Touch singleton: drives water reminder notifications
-        GoogleDriveService.configured; // Touch singleton: keeps scheduled backups independent of Settings
-        AppStats.stateDir; // Instantiate: starts the usage sampler, which must collect whether or not the overlay is open
-        TilingAssistant.enabled; // Touch singleton: watches for window drags, does nothing while disabled
-        TouchGestureService.enabled; // Touch singleton: starts passive touch input helper daemon
+        SoundService.indexReady;
+        VideoColorSampler.active;
+        WaterReminderService.enabled;
+        GoogleDriveService.configured;
+        AppStats.stateDir;
+        TilingAssistant.enabled;
+        TouchGestureService.enabled;
         if (Config.options && Config.options.policies && Config.options.policies.phone !== 0) {
             KdeConnectService.available;
             PhoneContactsService.available;
@@ -54,7 +53,6 @@ ShellRoot {
         root.applyOpenRgbIfEnabled();
     }
 
-    // Panel families
     property var families: ["ii", "waffle"]
     function cyclePanelFamily() {
         const currentIndex = families.indexOf(Config.options.panelFamily);
@@ -105,10 +103,6 @@ ShellRoot {
         component: WaffleFamily {}
     }
 
-    // Settings app loaded in-process once requested, then kept alive briefly
-    // for fast re-opens. After the delay we drop the component to recover
-    // its QML memory. Positive configured delays are capped at five seconds;
-    // 0 still means keep it warm explicitly.
     readonly property int settingsUnloadCapSeconds: 5
 
     function settingsUnloadDelaySeconds() {
@@ -129,47 +123,52 @@ ShellRoot {
         asynchronous: true
         source: "SettingsWindow.qml"
 
-        // When settings closes, schedule an unload pass. If the user
-        // reopens before the timer fires, the timer is reset and we
-        // keep the warm component.
+        function unloadNow() {
+            if (GlobalStates.settingsOpen)
+                return;
+            settingsUnloadTimer.stop();
+            SearchRegistry.clearIndex();
+            ThemePreviewCache.release();
+            WallpaperPreviewCache.release();
+            settingsLoader.loadedOnce = false;
+        }
+
         Timer {
             id: settingsUnloadTimer
             interval: root.settingsUnloadDelaySeconds() * 1000
             repeat: false
-            onTriggered: {
-                if (GlobalStates.settingsOpen)
-                    return
-                // The visual Loader only owns the Settings object tree. These
-                // singletons outlive it, so release their page-specific data
-                // before dropping the component as well.
-                SearchRegistry.clearIndex()
-                ThemePreviewCache.release()
-                WallpaperPreviewCache.release()
-                settingsLoader.loadedOnce = false
-            }
+            onTriggered: settingsLoader.unloadNow()
         }
 
         Connections {
             target: GlobalStates
             function onSettingsOpenChanged() {
                 if (GlobalStates.settingsOpen) {
-                    settingsUnloadTimer.stop()
+                    settingsUnloadTimer.stop();
                     if (!settingsLoader.loadedOnce)
-                        settingsLoader.loadedOnce = true
+                        settingsLoader.loadedOnce = true;
                 } else {
-                    const s = root.settingsUnloadDelaySeconds()
+                    const s = root.settingsUnloadDelaySeconds();
                     if (s > 0) {
-                        settingsUnloadTimer.interval = s * 1000
-                        settingsUnloadTimer.restart()
+                        settingsUnloadTimer.interval = s * 1000;
+                        settingsUnloadTimer.restart();
                     }
                 }
             }
         }
+
+        // Preset application is different from an ordinary Settings close: the
+        // entire config/theme graph is about to invalidate. Destroy the heavy
+        // Settings tree immediately instead of keeping it warm for five seconds.
+        Connections {
+            target: PresetManager
+            function onApplyingChanged() {
+                if (PresetManager.applying)
+                    settingsLoader.unloadNow();
+            }
+        }
     }
 
-    // Welcome runs in-process so it shares Config, GlobalStates and the same
-    // Quickshell lifecycle as Settings. Unlike Settings, the onboarding is
-    // destroyed as soon as it closes so costly page trees do not stay warm.
     Loader {
         id: welcomeLoader
         active: Config.ready && GlobalStates.welcomeOpen
@@ -177,7 +176,6 @@ ShellRoot {
         source: "modules/welcome/WelcomeWindow.qml"
     }
 
-    // Shortcuts
     IpcHandler {
         target: "panelFamily"
 
@@ -189,7 +187,6 @@ ShellRoot {
     GlobalShortcut {
         name: "panelFamilyCycle"
         description: "Cycles panel family"
-
         onPressed: root.cyclePanelFamily()
     }
 }

--- a/dots/.config/quickshell/ii/shell.qml
+++ b/dots/.config/quickshell/ii/shell.qml
@@ -21,6 +21,7 @@ ShellRoot {
     property string openRgbApplyScript: Quickshell.shellPath("scripts/colors/openRGB/apply_openrgb.py")
     property bool openRgbStartupApplied: false
 
+    // Stuff for every panel family
     ReloadPopup {}
 
     Component.onCompleted: {
@@ -38,13 +39,13 @@ ShellRoot {
         Updates.load();
         DarkModeService.automatic;
         ChangelogService.load();
-        SoundService.indexReady;
-        VideoColorSampler.active;
-        WaterReminderService.enabled;
-        GoogleDriveService.configured;
-        AppStats.stateDir;
-        TilingAssistant.enabled;
-        TouchGestureService.enabled;
+        SoundService.indexReady; // Instantiate: scans sound themes, plays login sound if enabled
+        VideoColorSampler.active; // Touch singleton to initialize
+        WaterReminderService.enabled; // Touch singleton: drives water reminder notifications
+        GoogleDriveService.configured; // Touch singleton: keeps scheduled backups independent of Settings
+        AppStats.stateDir; // Instantiate: starts the usage sampler, which must collect whether or not the overlay is open
+        TilingAssistant.enabled; // Touch singleton: watches for window drags, does nothing while disabled
+        TouchGestureService.enabled; // Touch singleton: starts passive touch input helper daemon
         if (Config.options && Config.options.policies && Config.options.policies.phone !== 0) {
             KdeConnectService.available;
             PhoneContactsService.available;
@@ -53,6 +54,7 @@ ShellRoot {
         root.applyOpenRgbIfEnabled();
     }
 
+    // Panel families
     property var families: ["ii", "waffle"]
     function cyclePanelFamily() {
         const currentIndex = families.indexOf(Config.options.panelFamily);
@@ -103,6 +105,10 @@ ShellRoot {
         component: WaffleFamily {}
     }
 
+    // Settings app loaded in-process once requested, then kept alive briefly
+    // for fast re-opens. After the delay we drop the component to recover
+    // its QML memory. Positive configured delays are capped at five seconds;
+    // 0 still means keep it warm explicitly.
     readonly property int settingsUnloadCapSeconds: 5
 
     function settingsUnloadDelaySeconds() {
@@ -127,12 +133,17 @@ ShellRoot {
             if (GlobalStates.settingsOpen)
                 return;
             settingsUnloadTimer.stop();
+            // The visual Loader only owns the Settings object tree. These
+            // singletons outlive it, so release their page-specific data too.
             SearchRegistry.clearIndex();
             ThemePreviewCache.release();
             WallpaperPreviewCache.release();
             settingsLoader.loadedOnce = false;
         }
 
+        // When settings closes, schedule an unload pass. If the user
+        // reopens before the timer fires, the timer is reset and we
+        // keep the warm component.
         Timer {
             id: settingsUnloadTimer
             interval: root.settingsUnloadDelaySeconds() * 1000
@@ -144,14 +155,14 @@ ShellRoot {
             target: GlobalStates
             function onSettingsOpenChanged() {
                 if (GlobalStates.settingsOpen) {
-                    settingsUnloadTimer.stop();
+                    settingsUnloadTimer.stop()
                     if (!settingsLoader.loadedOnce)
-                        settingsLoader.loadedOnce = true;
+                        settingsLoader.loadedOnce = true
                 } else {
-                    const s = root.settingsUnloadDelaySeconds();
+                    const s = root.settingsUnloadDelaySeconds()
                     if (s > 0) {
-                        settingsUnloadTimer.interval = s * 1000;
-                        settingsUnloadTimer.restart();
+                        settingsUnloadTimer.interval = s * 1000
+                        settingsUnloadTimer.restart()
                     }
                 }
             }
@@ -169,6 +180,9 @@ ShellRoot {
         }
     }
 
+    // Welcome runs in-process so it shares Config, GlobalStates and the same
+    // Quickshell lifecycle as Settings. Unlike Settings, the onboarding is
+    // destroyed as soon as it closes so costly page trees do not stay warm.
     Loader {
         id: welcomeLoader
         active: Config.ready && GlobalStates.welcomeOpen
@@ -176,6 +190,7 @@ ShellRoot {
         source: "modules/welcome/WelcomeWindow.qml"
     }
 
+    // Shortcuts
     IpcHandler {
         target: "panelFamily"
 
@@ -187,6 +202,7 @@ ShellRoot {
     GlobalShortcut {
         name: "panelFamilyCycle"
         description: "Cycles panel family"
+
         onPressed: root.cyclePanelFamily()
     }
 }


### PR DESCRIPTION
## Describe your changes

This draft aggressively restructures preset application around a **one-commit / one-theme-apply critical path** so switching presets feels immediate instead of spawning a large synchronous fan-out from Settings.

### Critical-path changes

- add a `PresetManager` singleton as the single coordinator for preset application
- close Settings before the config mutation and immediately unload its heavy QML tree during a preset switch
- replace shell-expanded preset commands with direct argv execution
- atomically deep-merge presets into `config.json`, preserving keys introduced by newer shell versions
- add a request token + file lock so concurrent/rapid requests are **latest-wins** and an older request cannot overwrite a newer one
- pre-normalize video/WPE constraints before the single config commit
- avoid the reactive `Wallpapers` constraint save when the loaded config is already normalized

### Cache-first theme application

- save/update snapshots the already-generated `colors.json` and `material_colors.scss` beside the preset cache
- cached presets apply config + palette through atomic filesystem replaces instead of running the full `switchwall.sh` pipeline
- palette caches carry a config fingerprint and are rejected after the preset JSON is edited/re-written
- export/import carries the optional preset palette cache and fingerprints the sanitized portable config
- cached palettes are rejected when their light/dark mode does not match the current mode, preventing recursive `darkmodeChanged` wallpaper work

### Legacy/imported preset fallback

Presets without a valid cache still commit their config immediately, then warm the theme **after yielding the first frame** in a cancellable process group. The warmup:

- is request-token guarded, so stale work cannot win
- avoids `--all-previews`
- handles static images, video thumbnails/first-frame extraction, and Wallpaper Engine workshop previews
- respects both color engines (`generate_colors_material.py` and `generate_colors_material_vynx.py`)
- mirrors the fork backend's `scheme-intense -> scheme-fidelity + boost` behavior
- fills and fingerprints the cache for the next switch
- preserves the current palette rather than generating from an unsafe/stale source when no valid WPE/video preview can be resolved
- validates the stored warmup PID against `/proc/<pid>/cmdline` before signalling a process group, making stale PID reuse harmless

### Reduce invalidation/process fan-out

- coalesce `MaterialThemeLoader` disk notifications into one palette application
- fingerprint theme payloads to skip duplicate reapplication
- only assign M3 colors whose values actually changed
- avoid assigning `darkmode` when unchanged
- deduplicate `HyprlandSettings.updateAppLaunchAnimation()` so a config reload no longer spawns four `hyprctl eval` processes unless that animation config actually changed
- defer terminal/OpenRGB, VS Code, YTMusic, icon recoloring and KDE integration until after the shell has had a chance to render the new preset
- use the matching `applycolor` backend for the preset's selected color engine

### Expected behavior

For a normal saved/updated preset with a valid warm cache, the intended hot path is now approximately:

`click -> close/unload Settings -> atomic config commit -> atomic cached palette swap -> render -> deferred integrations`

instead of:

`click -> full config replacement -> Settings stays alive -> reactive saves/reloads -> switchwall/matugen/previews/recolor/app integrations -> repeated palette invalidations`

## Is it ready? Questions/feedback needed?

**Draft intentionally.** The code has been reviewed and the executable validations available in this environment pass, but the final confidence gate must be a real Hyprland + Quickshell runtime test on the target machine.

### Validation completed

- `presets_helper.py`: `python3 -m py_compile` ✅
- atomic deep merge preserves newer config keys ✅
- video/WPE constraint normalization test ✅
- latest-request/superseded apply behavior tested ✅
- valid cached preset apply behavior tested ✅
- manual preset edit invalidates cache and falls back to warmup ✅
- `fork` + `scheme-intense` warmup selects the Vynx material generator and fidelity Matugen path ✅
- `presets.sh`: `bash -n` ✅
- `preset_generate_theme.sh`: `bash -n` ✅
- `preset_post_apply.sh`: `bash -n` ✅
- reviewed current Quickshell `FileView`/`JsonAdapter` API usage against official docs ✅
- final changed-file list is limited to the 10 preset/performance-related files ✅
- branch is still based directly on the current `dev` head and GitHub reports the PR mergeable ✅

There is no `qmllint`, `qmlformat`, `quickshell`/`qs`, or QML test runner installed in this execution environment, and the repository currently has no QML/test CI workflow. I am therefore not treating static review as a substitute for a real shell launch.

### Runtime checklist before marking ready

- alternate two cached static-image presets and verify no visible Settings freeze
- issue overlapping preset requests and confirm the newest request always wins
- test an old preset with no cache; first switch should stay responsive and subsequent switch should use cache
- test imported ZIP/JSON presets
- test both `vynx` and `fork` color-engine presets
- test `scheme-intense`
- test video wallpaper preset
- test Wallpaper Engine preset
- test light/dark mode with separate wallpapers enabled
- watch `qs -c ii` logs for QML/runtime warnings
- compare config/theme file write counts and subjective frame pacing against `dev`
