### PR TITLE
PERF: screenshot / region selector

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Directories.qml
+++ b/dots/.config/quickshell/ii/modules/common/Directories.qml
@@ -108,5 +108,6 @@ Singleton {
         Quickshell.execDetached(["mkdir", "-p", `${userActions}`]);
         Quickshell.execDetached(["mkdir", "-p", `${userWidgetsPath}`]);
         Quickshell.execDetached(["rm", "-rf", `${tempImages}`]);
+        Quickshell.execDetached(["mkdir", "-p", `${screenshotTemp}`]);
     }
 }

--- a/dots/.config/quickshell/ii/modules/common/utils/ScreenshotAction.qml
+++ b/dots/.config/quickshell/ii/modules/common/utils/ScreenshotAction.qml
@@ -40,8 +40,9 @@ Singleton {
         const rw = Math.round(width);
         const rh = Math.round(height);
         const cropBase = `magick ${StringUtils.shellSingleQuoteEscape(screenshotPath)} ` + `-crop ${rw}x${rh}+${rx}+${ry} +repage`;
-        const cropToStdout = `${cropBase} -`;
-        const cropInPlace = `${cropBase} '${StringUtils.shellSingleQuoteEscape(screenshotPath)}'`;
+        // Force PNG so clipboard/tesseract stay PNG even when grim writes ppm.
+        const cropToStdout = `${cropBase} png:-`;
+        const cropInPlace = `${cropBase} 'png:${StringUtils.shellSingleQuoteEscape(screenshotPath)}'`;
         const cleanup = (Config.options.regionSelector.enableOverlay ?? true) ? ":" : `rm '${StringUtils.shellSingleQuoteEscape(screenshotPath)}'`;
         const slurpRegion = `${rx},${ry} ${rw}x${rh}`;
         const uploadAndGetUrl = filePath => {

--- a/dots/.config/quickshell/ii/modules/common/utils/TempScreenshotProcess.qml
+++ b/dots/.config/quickshell/ii/modules/common/utils/TempScreenshotProcess.qml
@@ -9,6 +9,32 @@ Process {
     running: true
     property string screenshotDir: Directories.screenshotTemp
     required property ShellScreen screen
-    property string screenshotPath: `${screenshotDir}/image-${screen.name}`
-    command: ["bash", "-c", `mkdir -p '${StringUtils.shellSingleQuoteEscape(screenshotDir)}' && grim -o '${StringUtils.shellSingleQuoteEscape(screen.name)}' '${StringUtils.shellSingleQuoteEscape(screenshotPath)}'`]
+    property string screenshotPath: `${screenshotDir}/image-${screen.name}.ppm`
+    property bool completed: false
+    property int startedToken: 0
+    property bool restarting: false
+    // ppm skips PNG compression, which is the slow part of grim. Magick/Qt/OpenCV
+    // all sniff the format, and ScreenshotAction forces png:- on clipboard output.
+    command: ["bash", "-c", `mkdir -p '${StringUtils.shellSingleQuoteEscape(screenshotDir)}' && exec grim -t ppm -o '${StringUtils.shellSingleQuoteEscape(screen.name)}' '${StringUtils.shellSingleQuoteEscape(screenshotPath)}'`]
+
+    onRunningChanged: {
+        if (running) {
+            screenshotProc.completed = false;
+            return;
+        }
+        if (screenshotProc.restarting || screenshotProc.startedToken === 0)
+            return;
+        screenshotProc.completed = true;
+    }
+
+    function recapture(token) {
+        screenshotProc.completed = false;
+        screenshotProc.startedToken = token;
+        if (screenshotProc.running) {
+            screenshotProc.restarting = true;
+            screenshotProc.running = false;
+            screenshotProc.restarting = false;
+        }
+        screenshotProc.running = true;
+    }
 }

--- a/dots/.config/quickshell/ii/modules/common/utils/TempScreenshotProcess.qml
+++ b/dots/.config/quickshell/ii/modules/common/utils/TempScreenshotProcess.qml
@@ -20,12 +20,20 @@ Process {
     property string format: "png"
     command: ["bash", "-c", `mkdir -p '${StringUtils.shellSingleQuoteEscape(screenshotDir)}' && exec grim -t ${StringUtils.shellSingleQuoteEscape(format)} -o '${StringUtils.shellSingleQuoteEscape(screen.name)}' '${StringUtils.shellSingleQuoteEscape(screenshotPath)}'`]
 
+    // runningChanged is emitted from Process::onFinished, never synchronously
+    // from `running = false` (that only sends SIGTERM), so the restart guard has
+    // to be cleared here — otherwise a terminated grim reports its truncated
+    // file as a finished capture.
     onRunningChanged: {
         if (running) {
             screenshotProc.completed = false;
             return;
         }
-        if (screenshotProc.restarting || screenshotProc.startedToken === 0)
+        if (screenshotProc.restarting) {
+            screenshotProc.restarting = false;
+            return;
+        }
+        if (screenshotProc.startedToken === 0)
             return;
         screenshotProc.completed = true;
     }
@@ -33,11 +41,10 @@ Process {
     function recapture(token) {
         screenshotProc.completed = false;
         screenshotProc.startedToken = token;
-        if (screenshotProc.running) {
+        if (screenshotProc.running)
             screenshotProc.restarting = true;
-            screenshotProc.running = false;
-            screenshotProc.restarting = false;
-        }
+        // Process restarts itself on finish when running is set back to true.
+        screenshotProc.running = false;
         screenshotProc.running = true;
     }
 }

--- a/dots/.config/quickshell/ii/modules/common/utils/TempScreenshotProcess.qml
+++ b/dots/.config/quickshell/ii/modules/common/utils/TempScreenshotProcess.qml
@@ -9,13 +9,16 @@ Process {
     running: true
     property string screenshotDir: Directories.screenshotTemp
     required property ShellScreen screen
-    property string screenshotPath: `${screenshotDir}/image-${screen.name}.ppm`
+    property string screenshotPath: `${screenshotDir}/image-${screen.name}`
     property bool completed: false
     property int startedToken: 0
     property bool restarting: false
-    // ppm skips PNG compression, which is the slow part of grim. Magick/Qt/OpenCV
-    // all sniff the format, and ScreenshotAction forces png:- on clipboard output.
-    command: ["bash", "-c", `mkdir -p '${StringUtils.shellSingleQuoteEscape(screenshotDir)}' && exec grim -t ppm -o '${StringUtils.shellSingleQuoteEscape(screen.name)}' '${StringUtils.shellSingleQuoteEscape(screenshotPath)}'`]
+    // grim output format. ppm skips PNG compression, which is the slow part of
+    // grim, but the file is then only safe for consumers that sniff the format
+    // (magick/Qt/OpenCV). Anything shipping the bytes as-is to an external API
+    // must stay on png, so this is opt-in rather than the default.
+    property string format: "png"
+    command: ["bash", "-c", `mkdir -p '${StringUtils.shellSingleQuoteEscape(screenshotDir)}' && exec grim -t ${StringUtils.shellSingleQuoteEscape(format)} -o '${StringUtils.shellSingleQuoteEscape(screen.name)}' '${StringUtils.shellSingleQuoteEscape(screenshotPath)}'`]
 
     onRunningChanged: {
         if (running) {

--- a/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelection.qml
+++ b/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelection.qml
@@ -15,11 +15,10 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
 import Quickshell.Hyprland
-import QtQuick.Effects
 
 PanelWindow {
     id: root
-    visible: false
+    visible: GlobalStates.regionSelectorOpen && root.preparationDone
     color: "transparent"
     WlrLayershell.namespace: "quickshell:regionSelector"
     WlrLayershell.layer: WlrLayer.Overlay
@@ -88,12 +87,12 @@ PanelWindow {
     readonly property real captureScale: (captureProbe.implicitWidth > 0 && root.screen.width > 0) ? (captureProbe.implicitWidth / root.screen.width) : (root.monitorScale > 0 ? root.monitorScale : 1)
     Image {
         id: captureProbe
-        source: root.inlineEditorActive ? root.screenshotPath : ""
+        source: root.inlineEditorActive ? `file://${root.screenshotPath}` : ""
         width: 0
         height: 0
         visible: false
         asynchronous: true
-        cache: true
+        cache: false
     }
     property bool shapePopupVisible: false
     property bool colorPopupVisible: false
@@ -326,7 +325,8 @@ PanelWindow {
         }
         root.annotations = newList;
         root.editingTextId = null;
-        editorOverlay.forceActiveFocus();
+        if (editorOverlayLoader.item)
+            editorOverlayLoader.item.forceActiveFocus();
     }
 
     function clearEditor() {
@@ -350,8 +350,15 @@ PanelWindow {
         root.dragDiffX = 0;
         root.dragDiffY = 0;
         root.points = [];
+        root.editorRegionX = 0;
+        root.editorRegionY = 0;
         root.editorRegionW = 0;
         root.editorRegionH = 0;
+        root.mouseButton = null;
+        root.targetedRegionX = -1;
+        root.targetedRegionY = -1;
+        root.targetedRegionWidth = 0;
+        root.targetedRegionHeight = 0;
     }
 
     // Grab the annotated selection to a temp PNG at the capture's native
@@ -492,7 +499,9 @@ PanelWindow {
     readonly property real monitorOffsetX: hyprlandMonitor.x
     readonly property real monitorOffsetY: hyprlandMonitor.y
     property int activeWorkspaceId: hyprlandMonitor.activeWorkspace?.id ?? 0
-    property string screenshotPath: `${root.screenshotDir}/image-${screen.name}`
+    property string screenshotPath: `${root.screenshotDir}/image-${screen.name}.ppm`
+    property bool captureReady: false
+    property int captureToken: 0
     property real dragStartX: 0
     property real dragStartY: 0
     property real draggingX: 0
@@ -548,12 +557,23 @@ PanelWindow {
     function targetedRegionValid() {
         return (root.targetedRegionX >= 0 && root.targetedRegionY >= 0);
     }
+    // regionX/Y/Width/Height are bindings over dragStart/dragging. Assigning
+    // those computed properties breaks the bindings, with a sticky-loaded
+    // overlay that freeze is the next session's "stuck" previous region.
+    function setRegion(x, y, w, h) {
+        root.dragStartX = x;
+        root.dragStartY = y;
+        root.draggingX = x + w;
+        root.draggingY = y + h;
+    }
     function setRegionToTargeted() {
         const padding = Config.options.regionSelector.targetRegions.selectionPadding; // Make borders not cut off n stuff
-        root.regionX = root.targetedRegionX - padding;
-        root.regionY = root.targetedRegionY - padding;
-        root.regionWidth = root.targetedRegionWidth + padding * 2;
-        root.regionHeight = root.targetedRegionHeight + padding * 2;
+        root.setRegion(
+					root.targetedRegionX - padding, 
+					root.targetedRegionY - padding, 
+					root.targetedRegionWidth + padding * 2, 
+					root.targetedRegionHeight + padding * 2
+					);
     }
 
     function updateTargetedRegion(x, y) {
@@ -604,47 +624,81 @@ PanelWindow {
     property real regionX: Math.min(dragStartX, draggingX)
     property real regionY: Math.min(dragStartY, draggingY)
 
-    // Screenshot stuff
-    TempScreenshotProcess {
-        id: screenshotProc
-        running: true
-        screen: root.screen
-        screenshotDir: root.screenshotDir
-        screenshotPath: root.screenshotPath
-        onExited: (exitCode, exitStatus) => {
-            if (root.enableContentRegions)
-                imageDetectionProcess.running = true;
-            root.preparationDone = !checkRecordingProc.running;
-        }
-    }
+    // Screenshot is taken by the parent Scope as soon as screenshot mode is
+    // requested, in parallel with creating this overlay. We only map once the
+    // freeze-frame file is ready so the overlay is never baked into the capture.
     property bool isRecording: root.action === RegionSelection.SnipAction.Record || root.action === RegionSelection.SnipAction.RecordWithSound
     property bool recordingShouldStop: false
-    Process {
-        id: checkRecordingProc
-        running: isRecording
-        command: ["bash", "-c", "pidof wf-recorder > /dev/null 2>&1 || (pgrep -x obs > /dev/null 2>&1 && python3 '" + Directories.scriptPath + "/videos/obs_control.py' status 2>/dev/null | grep -q active)"]
-        onExited: (exitCode, exitStatus) => {
-            root.preparationDone = !screenshotProc.running;
-            root.recordingShouldStop = (exitCode === 0);
-        }
-    }
     property bool preparationDone: false
-    onPreparationDoneChanged: {
-        if (!preparationDone)
+
+    function tryFinishPreparation() {
+        if (root.captureToken <= 0 || !root.captureReady)
+            return;
+        if (root.isRecording && checkRecordingProc.running)
             return;
         if (root.isRecording && root.recordingShouldStop) {
             Quickshell.execDetached([Directories.recordScriptPath]);
             root.dismiss();
             return;
         }
+        if (root.enableContentRegions) {
+            imageDetectionProcess.running = false;
+            imageDetectionProcess.running = true;
+        }
         // Load synchronously before mapping so the first painted frame already
         // has the frozen screen; an async load could flash an empty window.
+        // Cache-bust because screenshotPath is reused across activations.
         freezeFrame.source = `file://${root.screenshotPath}`;
-        root.visible = true;
+        root.preparationDone = true;
+    }
+
+    onCaptureReadyChanged: root.tryFinishPreparation()
+
+    onCaptureTokenChanged: {
+        freezeFrame.source = "";
+        root.preparationDone = false;
+        root.recordingShouldStop = false;
+        root.imageRegions = [];
+        imageDetectionProcess.running = false;
+        root.clearEditor();
+        if (root.isRecording) {
+            checkRecordingProc.running = false;
+            checkRecordingProc.running = true;
+        }
+        root.tryFinishPreparation();
+    }
+
+    Process {
+        id: checkRecordingProc
+        running: false
+        command: ["bash", "-c", "pidof wf-recorder > /dev/null 2>&1 || (pgrep -x obs > /dev/null 2>&1 && python3 '" + Directories.scriptPath + "/videos/obs_control.py' status 2>/dev/null | grep -q active)"]
+        onExited: (exitCode, exitStatus) => {
+            root.recordingShouldStop = (exitCode === 0);
+            root.tryFinishPreparation();
+        }
+    }
+
+    Component.onCompleted: {
+        if (root.isRecording)
+            checkRecordingProc.running = true;
+        root.tryFinishPreparation();
     }
 
     onVisibleChanged: {
         if (!root.visible) {
+            root.clearEditor();
+        }
+    }
+
+    Connections {
+        target: GlobalStates
+        function onRegionSelectorOpenChanged() {
+            if (GlobalStates.regionSelectorOpen)
+                return;
+            root.preparationDone = false;
+            freezeFrame.source = "";
+            root.imageRegions = [];
+            imageDetectionProcess.running = false;
             root.clearEditor();
         }
     }
@@ -660,8 +714,8 @@ PanelWindow {
         }
     }
 
-    function getScreenshotAction() {
-        switch (root.action) {
+    function actionToScreenshotAction(snipAction) {
+        switch (snipAction) {
         case RegionSelection.SnipAction.Copy:
             return ScreenshotAction.Action.Copy;
         case RegionSelection.SnipAction.Edit:
@@ -684,40 +738,47 @@ PanelWindow {
     }
 
     // Execution after selection
+    function getScreenshotAction() {
+        return root.actionToScreenshotAction(root.action);
+    }
+
     function snip() {
-        // Validity check
-        if (root.regionWidth <= 0 || root.regionHeight <= 0) {
+        var rx = root.regionX;
+        var ry = root.regionY;
+        var rw = root.regionWidth;
+        var rh = root.regionHeight;
+        if (rw <= 0 || rh <= 0) {
             console.warn("[Region Selector] Invalid region size, skipping snip.");
             root.dismiss();
+            return;
         }
 
-        // Clamp region to screen bounds
-        root.regionX = Math.max(0, Math.min(root.regionX, root.screen.width - root.regionWidth));
-        root.regionY = Math.max(0, Math.min(root.regionY, root.screen.height - root.regionHeight));
-        root.regionWidth = Math.max(0, Math.min(root.regionWidth, root.screen.width - root.regionX));
-        root.regionHeight = Math.max(0, Math.min(root.regionHeight, root.screen.height - root.regionY));
+        rx = Math.max(0, Math.min(rx, root.screen.width - rw));
+        ry = Math.max(0, Math.min(ry, root.screen.height - rh));
+        rw = Math.max(0, Math.min(rw, root.screen.width - rx));
+        rh = Math.max(0, Math.min(rh, root.screen.height - ry));
 
-        // Adjust action
-        if (root.action === RegionSelection.SnipAction.Copy || root.action === RegionSelection.SnipAction.Edit) {
-            root.action = root.mouseButton === Qt.RightButton ? RegionSelection.SnipAction.Edit : RegionSelection.SnipAction.Copy;
+        var snipAction = root.action;
+        if (snipAction === RegionSelection.SnipAction.Copy || snipAction === RegionSelection.SnipAction.Edit) {
+            snipAction = root.mouseButton === Qt.RightButton ? RegionSelection.SnipAction.Edit : RegionSelection.SnipAction.Copy;
         }
-        if (root.action === RegionSelection.SnipAction.Search || root.action === RegionSelection.SnipAction.AskAI) {
-            root.action = root.mouseButton === Qt.RightButton ? RegionSelection.SnipAction.AskAI : RegionSelection.SnipAction.Search;
+        if (snipAction === RegionSelection.SnipAction.Search || snipAction === RegionSelection.SnipAction.AskAI) {
+            snipAction = root.mouseButton === Qt.RightButton ? RegionSelection.SnipAction.AskAI : RegionSelection.SnipAction.Search;
         }
 
         const screenshotDir = Config.options.screenSnip.savePath !== "" ? //
         Config.options.screenSnip.savePath : "";
-        var screenshotAction = root.getScreenshotAction();
-        const command = ScreenshotAction.getCommand(root.regionX * root.monitorScale //
-        , root.regionY * root.monitorScale //
-        , root.regionWidth * root.monitorScale//
-        , root.regionHeight * root.monitorScale //
+        var screenshotAction = root.actionToScreenshotAction(snipAction);
+        const command = ScreenshotAction.getCommand(rx * root.monitorScale //
+        , ry * root.monitorScale //
+        , rw * root.monitorScale//
+        , rh * root.monitorScale //
         , root.screenshotPath //
         , screenshotAction //
         , screenshotDir);
         Quickshell.execDetached(command);
         ScreenshotAction.playShutterSound(screenshotAction);
-        if (root.action === RegionSelection.SnipAction.AskAI) {
+        if (snipAction === RegionSelection.SnipAction.AskAI) {
             Ai.handleClipboardAndAttach();
             GlobalStates.policiesPanelOpen = true;
         }
@@ -725,10 +786,10 @@ PanelWindow {
         if (Config.options.regionSelector.enableOverlay ?? true) {
             GlobalStates.screenshotOverlayMonitor = root.screen?.name ?? ""
             GlobalStates.screenshotOverlayImagePath = root.screenshotPath;
-            GlobalStates.screenshotOverlayRegionX = root.regionX * root.monitorScale;
-            GlobalStates.screenshotOverlayRegionY = root.regionY * root.monitorScale;
-            GlobalStates.screenshotOverlayRegionW = root.regionWidth * root.monitorScale;
-            GlobalStates.screenshotOverlayRegionH = root.regionHeight * root.monitorScale;
+            GlobalStates.screenshotOverlayRegionX = rx * root.monitorScale;
+            GlobalStates.screenshotOverlayRegionY = ry * root.monitorScale;
+            GlobalStates.screenshotOverlayRegionW = rw * root.monitorScale;
+            GlobalStates.screenshotOverlayRegionH = rh * root.monitorScale;
             GlobalStates.screenshotOverlayOpen = true;
         }
         root.dismiss();
@@ -809,10 +870,7 @@ PanelWindow {
                 const minX = Math.min(...dragPoints.map(p => p.x));
                 const maxY = Math.max(...dragPoints.map(p => p.y));
                 const minY = Math.min(...dragPoints.map(p => p.y));
-                root.regionX = minX - padding;
-                root.regionY = minY - padding;
-                root.regionWidth = maxX - minX + padding * 2;
-                root.regionHeight = maxY - minY + padding * 2;
+                root.setRegion(minX - padding, minY - padding, maxX - minX + padding * 2, maxY - minY + padding * 2);
             }
             // Inline editor intercept (right-click only, when editor enabled)
             if (root.mouseButton === Qt.RightButton && Config.options.regionSelector.annotation.enableInlineEditor && root.selectionMode !== RegionSelection.SelectionMode.Circle && root.regionWidth > 0 && root.regionHeight > 0) {
@@ -1006,13 +1064,26 @@ PanelWindow {
         }
     }
 
-    // Inline editor overlay
-    Item {
-        id: editorOverlay
+    // Inline editor overlay — instantiated only when the user enters annotate
+    // mode so screenshot-open isn't paying for canvases, handles, and toolbars.
+    Loader {
+        id: editorOverlayLoader
         z: 10
-        visible: root.inlineEditorActive
         anchors.fill: parent
-        focus: root.inlineEditorActive
+        active: root.inlineEditorActive
+        onLoaded: {
+            if (item)
+                item.forceActiveFocus();
+        }
+        sourceComponent: editorOverlayComponent
+    }
+
+    Component {
+        id: editorOverlayComponent
+        Item {
+            id: editorOverlay
+            anchors.fill: parent
+            focus: true
         Keys.onPressed: event => {
             if (event.key === Qt.Key_Escape) {
                 root.dismiss();
@@ -1053,7 +1124,7 @@ PanelWindow {
 
             Image {
                 id: editorImage
-                source: root.inlineEditorActive ? root.screenshotPath : ""
+                source: root.inlineEditorActive ? `file://${root.screenshotPath}` : ""
                 width: root.screen.width
                 height: root.screen.height
                 x: -root.editorRegionX
@@ -2232,6 +2303,7 @@ PanelWindow {
                 id: editorToolbarInstance
                 editor: root
             }
+        }
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelection.qml
+++ b/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelection.qml
@@ -341,6 +341,7 @@ PanelWindow {
         root.nextBadgeNumber = Config.options.regionSelector.annotation.badgeStartNumber;
         root.currentTool = "none";
         root.inlineEditorActive = false;
+        root.exporting = false;
         root.phase = RegionSelection.Phase.Select;
         root.dragging = false;
         root.dragStartX = 0;
@@ -365,15 +366,27 @@ PanelWindow {
     // resolution (e.g. 2880x1800 on a 1.5x display), hiding editor chrome for
     // the single frame of the grab, then hand the path to cb.
     function grabAnnotated(cb) {
-        var targetW = Math.round(root.editorRegionW * root.captureScale);
-        var targetH = Math.round(root.editorRegionH * root.captureScale);
+        const target = editorOverlayLoader.item?.grabTarget ?? null;
+        if (!target) {
+            console.warn("[Region Selector] No editor content to grab.");
+            root.exporting = false;
+            return;
+        }
+        const targetW = Math.round(root.editorRegionW * root.captureScale);
+        const targetH = Math.round(root.editorRegionH * root.captureScale);
         root.exporting = true;
-        editorContent.grabToImage(function (result) {
+        // grabToImage returns false when the item can't be rendered; without
+        // this, exporting sticks true and hides the toolbar for every later run.
+        const started = target.grabToImage(function (result) {
             var tempPath = "/tmp/quickshell-snip-" + Date.now() + ".png";
             result.saveToFile(tempPath);
             root.exporting = false;
             cb(tempPath);
         }, Qt.size(targetW, targetH));
+        if (!started) {
+            console.warn("[Region Selector] grabToImage failed to start.");
+            root.exporting = false;
+        }
     }
 
     function defaultSaveDir() {
@@ -568,12 +581,7 @@ PanelWindow {
     }
     function setRegionToTargeted() {
         const padding = Config.options.regionSelector.targetRegions.selectionPadding; // Make borders not cut off n stuff
-        root.setRegion(
-					root.targetedRegionX - padding, 
-					root.targetedRegionY - padding, 
-					root.targetedRegionWidth + padding * 2, 
-					root.targetedRegionHeight + padding * 2
-					);
+        root.setRegion(root.targetedRegionX - padding, root.targetedRegionY - padding, root.targetedRegionWidth + padding * 2, root.targetedRegionHeight + padding * 2);
     }
 
     function updateTargetedRegion(x, y) {
@@ -1084,6 +1092,9 @@ PanelWindow {
             id: editorOverlay
             anchors.fill: parent
             focus: true
+            // editorContent is scoped to this Component, so grabAnnotated() on
+            // the outer root can only reach it through the Loader's item.
+            readonly property Item grabTarget: editorContent
         Keys.onPressed: event => {
             if (event.key === Qt.Key_Escape) {
                 root.dismiss();

--- a/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelector.qml
+++ b/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelector.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 import qs
 import qs.modules.common
+import qs.modules.common.utils
 import QtQuick
 import Quickshell
 import Quickshell.Io
@@ -15,24 +16,65 @@ Scope {
 
     property var action: RegionSelection.SnipAction.Copy
     property var selectionMode: RegionSelection.SelectionMode.RectCorners
+    // Bumped on every open so grim starts before (or while) the overlay tree
+    // is created, instead of waiting for RegionSelection to finish loading.
+    property int captureToken: 0
+
+    function beginCapture() {
+        root.captureToken += 1
+    }
+
+    function openSelector() {
+        root.beginCapture()
+        GlobalStates.regionSelectorOpen = true
+    }
 
     Variants {
         model: Quickshell.screens
-        
-        delegate: Loader {
-            id: regionSelectorLoader
+
+        delegate: Scope {
+            id: monitorScope
             required property var modelData
 
-            readonly property HyprlandMonitor monitor: Hyprland.monitorFor(regionSelectorLoader.modelData)
+            readonly property HyprlandMonitor monitor: Hyprland.monitorFor(monitorScope.modelData)
             property bool monitorIsFocused: (Hyprland.focusedMonitor?.id == monitor?.id)
+            readonly property bool monitorWantsSelector: !Config.options.regionSelector.showOnlyOnFocusedMonitor || monitorIsFocused
+            // Keep the overlay tree after the first open so later screenshots
+            // only wait on grim, not on rebuilding ~2k lines of QML.
+            property bool stickyLoaded: false
 
-            active: GlobalStates.regionSelectorOpen && (!Config.options.regionSelector.showOnlyOnFocusedMonitor || monitorIsFocused)
+            TempScreenshotProcess {
+                id: captureProc
+                running: false
+                screen: monitorScope.modelData
+                screenshotDir: Directories.screenshotTemp
+                screenshotPath: `${Directories.screenshotTemp}/image-${monitorScope.modelData.name}.ppm`
+            }
 
-            sourceComponent: RegionSelection {
-                screen: regionSelectorLoader.modelData
-                onDismiss: root.dismiss()
-                action: root.action
-                selectionMode: root.selectionMode
+            Connections {
+                target: root
+                function onCaptureTokenChanged() {
+                    if (!monitorScope.monitorWantsSelector)
+                        return
+                    captureProc.recapture(root.captureToken)
+                }
+            }
+
+            Loader {
+                id: regionSelectorLoader
+                active: (GlobalStates.regionSelectorOpen && monitorScope.monitorWantsSelector) || monitorScope.stickyLoaded
+                asynchronous: !GlobalStates.regionSelectorOpen
+                onLoaded: monitorScope.stickyLoaded = true
+
+                sourceComponent: RegionSelection {
+                    screen: monitorScope.modelData
+                    screenshotPath: captureProc.screenshotPath
+                    captureReady: captureProc.completed && captureProc.startedToken === root.captureToken
+                    captureToken: root.captureToken
+                    onDismiss: root.dismiss()
+                    action: root.action
+                    selectionMode: root.selectionMode
+                }
             }
         }
     }
@@ -40,7 +82,7 @@ Scope {
     function screenshot() {
         root.action = RegionSelection.SnipAction.Copy
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
-        GlobalStates.regionSelectorOpen = true
+        root.openSelector()
     }
 
     function search() {
@@ -50,35 +92,31 @@ Scope {
         } else {
             root.selectionMode = RegionSelection.SelectionMode.RectCorners
         }
-        GlobalStates.regionSelectorOpen = true
+        root.openSelector()
     }
 
     function ocr() {
         root.action = RegionSelection.SnipAction.CharRecognition
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
-        GlobalStates.regionSelectorOpen = true
+        root.openSelector()
     }
 
     function record() {
         root.action = RegionSelection.SnipAction.Record
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
-        // If already open then re-trigger to stop recording
-        if (GlobalStates.regionSelectorOpen) GlobalStates.regionSelectorOpen = false
-        GlobalStates.regionSelectorOpen = true
+        root.openSelector()
     }
 
     function recordWithSound() {
         root.action = RegionSelection.SnipAction.RecordWithSound
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
-        // If already open then re-trigger to stop recording
-        if (GlobalStates.regionSelectorOpen) GlobalStates.regionSelectorOpen = false
-        GlobalStates.regionSelectorOpen = true
+        root.openSelector()
     }
 
     function edit() {
         root.action = RegionSelection.SnipAction.Edit
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
-        GlobalStates.regionSelectorOpen = true
+        root.openSelector()
     }
 
     IpcHandler {

--- a/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelector.qml
+++ b/dots/.config/quickshell/ii/modules/ii/regionSelector/RegionSelector.qml
@@ -48,6 +48,7 @@ Scope {
                 running: false
                 screen: monitorScope.modelData
                 screenshotDir: Directories.screenshotTemp
+                format: "ppm"
                 screenshotPath: `${Directories.screenshotTemp}/image-${monitorScope.modelData.name}.ppm`
             }
 


### PR DESCRIPTION
## Describe your changes
Improves the speed of region selector. Uses different methods to make it load faster.
Load annotation thingie only when needed (previously it was loaded on plain screenshot too).
Capture freeze frames as PPM to avoid encoding.
And more in comments 

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yes

